### PR TITLE
Fix ThemeToggle content visibility in dark mode

### DIFF
--- a/THEMING.md
+++ b/THEMING.md
@@ -117,7 +117,9 @@ ShellNav, ShellMain, and EmptyState.
 
 Theme state helpers also live there: `ThemeProvider`, `ThemePicker`,
 `ThemeToggle`, and `useTheme`. `ThemeToggle` intentionally has no built-in
-icons; applications pass their own icon/content props.
+icons; applications pass their own icon/content props. The rendered content is
+wrapped in `data-slot="theme-toggle-content"` so icon and text compositions can
+be styled consistently across themes.
 The common wrapper components also emit familiar alias classes such as
 `alert`, `btn-group`, `btn-close`, `input-group`, `list-group`, and
 `pagination` so app-level CSS can stay close to the Bootstrap mental model

--- a/THEMING.md
+++ b/THEMING.md
@@ -119,7 +119,9 @@ Theme state helpers also live there: `ThemeProvider`, `ThemePicker`,
 `ThemeToggle`, and `useTheme`. `ThemeToggle` intentionally has no built-in
 icons; applications pass their own icon/content props. The rendered content is
 wrapped in `data-slot="theme-toggle-content"` so icon and text compositions can
-be styled consistently across themes.
+be styled consistently across themes. If you use icon children, the direct child
+icon is sized from `var(--ak-theme-toggle-icon-size, var(--ak-icon-size, 1em))`,
+so apps can override `--ak-theme-toggle-icon-size` to fit custom icon dimensions.
 The common wrapper components also emit familiar alias classes such as
 `alert`, `btn-group`, `btn-close`, `input-group`, `list-group`, and
 `pagination` so app-level CSS can stay close to the Bootstrap mental model

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -203,7 +203,7 @@ export function ThemeToggle(props: ThemeToggleProps): JSX.Element {
         if (!event.defaultPrevented) theme.setTheme(nextTheme);
       }}
     >
-      {content}
+      <span data-slot="theme-toggle-content">{content}</span>
     </Button>
   );
 }

--- a/src/themes/default/styles/actions/button.css
+++ b/src/themes/default/styles/actions/button.css
@@ -35,6 +35,21 @@
     opacity var(--ak-duration-fast) var(--ak-ease-standard);
 }
 
+:where([data-slot="theme-toggle-content"]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  min-inline-size: 0;
+}
+
+:where([data-slot="theme-toggle-content"]) > :where([data-slot="icon"], svg) {
+  flex: none;
+  inline-size: var(--ak-icon-size, 1em);
+  block-size: var(--ak-icon-size, 1em);
+  color: currentColor;
+}
+
 :where(.btn) > :where([data-slot="icon"], svg),
 :where([data-slot="button"]) > :where([data-slot="icon"], svg) {
   flex: none;

--- a/src/themes/default/styles/actions/button.css
+++ b/src/themes/default/styles/actions/button.css
@@ -36,6 +36,7 @@
 }
 
 :where([data-slot="theme-toggle-content"]) {
+  --_ak-theme-toggle-icon-size: var(--ak-theme-toggle-icon-size, var(--ak-icon-size, 1em));
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -45,8 +46,8 @@
 
 :where([data-slot="theme-toggle-content"]) > :where([data-slot="icon"], svg) {
   flex: none;
-  inline-size: var(--ak-icon-size, 1em);
-  block-size: var(--ak-icon-size, 1em);
+  inline-size: var(--_ak-theme-toggle-icon-size);
+  block-size: var(--_ak-theme-toggle-icon-size);
   color: currentColor;
 }
 

--- a/templates/theme/styles/actions/button.css
+++ b/templates/theme/styles/actions/button.css
@@ -35,6 +35,21 @@
     opacity var(--ak-duration-fast) var(--ak-ease-standard);
 }
 
+:where([data-slot="theme-toggle-content"]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  min-inline-size: 0;
+}
+
+:where([data-slot="theme-toggle-content"]) > :where([data-slot="icon"], svg) {
+  flex: none;
+  inline-size: var(--ak-icon-size, 1em);
+  block-size: var(--ak-icon-size, 1em);
+  color: currentColor;
+}
+
 :where(.btn) > :where([data-slot="icon"], svg),
 :where([data-slot="button"]) > :where([data-slot="icon"], svg) {
   flex: none;

--- a/templates/theme/styles/actions/button.css
+++ b/templates/theme/styles/actions/button.css
@@ -36,6 +36,7 @@
 }
 
 :where([data-slot="theme-toggle-content"]) {
+  --_ak-theme-toggle-icon-size: var(--ak-theme-toggle-icon-size, var(--ak-icon-size, 1em));
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -45,8 +46,8 @@
 
 :where([data-slot="theme-toggle-content"]) > :where([data-slot="icon"], svg) {
   flex: none;
-  inline-size: var(--ak-icon-size, 1em);
-  block-size: var(--ak-icon-size, 1em);
+  inline-size: var(--_ak-theme-toggle-icon-size);
+  block-size: var(--_ak-theme-toggle-icon-size);
   color: currentColor;
 }
 

--- a/tests/browser/theme-toggle-visibility.test.tsx
+++ b/tests/browser/theme-toggle-visibility.test.tsx
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { cleanupApp, createSPA } from "@askrjs/askr/boot";
+import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
+
+import { NavBrand, NavGroup, Navbar } from "../../src/navs";
+import { Shell, ShellMain, ShellNav } from "../../src/shells";
+import { ThemeProvider, ThemeToggle } from "../../src/theme";
+
+import "../../src/themes/default/index.css";
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("theme toggle visibility", () => {
+  let container: HTMLDivElement | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    window.history.replaceState({}, "", "/theme-visibility");
+    clearRoutes();
+  });
+
+  afterEach(() => {
+    if (container) {
+      cleanupApp(container);
+      container.remove();
+      container = undefined;
+    }
+
+    clearRoutes();
+    document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-theme-choice");
+  });
+
+  it("should keep toggle content visible after switching to dark mode", async () => {
+    route("/theme-visibility", () => (
+      <ThemeProvider defaultTheme="light">
+        <Shell variant="topbar">
+          <ShellNav>
+            <Navbar aria-label="Theme visibility">
+              <NavBrand>
+                <a href="/">
+                  <strong>Askr</strong>
+                </a>
+              </NavBrand>
+              <NavGroup align="end">
+                <ThemeToggle
+                  lightIcon={
+                    <svg
+                      aria-hidden="true"
+                      data-icon="sun"
+                      data-slot="icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      width="24"
+                    >
+                      <circle cx="12" cy="12" r="5" />
+                    </svg>
+                  }
+                  darkIcon={
+                    <svg
+                      aria-hidden="true"
+                      data-icon="moon"
+                      data-slot="icon"
+                      fill="none"
+                      height="24"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      width="24"
+                    >
+                      <path d="M15 4a7 7 0 1 0 5 12A7 7 0 0 1 15 4Z" />
+                    </svg>
+                  }
+                />
+                <ThemeToggle>{({ nextTheme }) => nextTheme}</ThemeToggle>
+              </NavGroup>
+            </Navbar>
+          </ShellNav>
+          <ShellMain>
+            <p>Shell content</p>
+          </ShellMain>
+        </Shell>
+      </ThemeProvider>
+    ));
+
+    await createSPA({ root: container!, manifest: getManifest() });
+    await settle();
+
+    const toggles = [
+      ...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? []),
+    ] as HTMLButtonElement[];
+    const iconToggle = toggles[0];
+    const textToggle = toggles[1];
+    const iconContent = iconToggle?.querySelector('[data-slot="theme-toggle-content"]');
+    const icon = iconToggle?.querySelector("svg") as SVGElement | null;
+
+    expect(iconToggle).not.toBeNull();
+    expect(textToggle).not.toBeNull();
+    expect(iconContent).not.toBeNull();
+    expect(iconToggle?.querySelectorAll("svg")).toHaveLength(1);
+    expect(icon?.getAttribute("data-icon")).toBe("sun");
+    expect(getComputedStyle(icon!).inlineSize).toBe("14px");
+    expect(getComputedStyle(icon!).blockSize).toBe("14px");
+    expect(textToggle?.textContent).toBe("dark");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+
+    iconToggle?.click();
+    await settle();
+
+    const togglesAfter = [
+      ...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? []),
+    ] as HTMLButtonElement[];
+    const iconToggleAfter = togglesAfter[0];
+    const textToggleAfter = togglesAfter[1];
+    const iconAfter = iconToggleAfter?.querySelector("svg") as SVGElement | null;
+
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+    expect(iconToggleAfter?.getAttribute("data-theme-choice")).toBe("dark");
+    expect(iconToggleAfter?.querySelector('[data-slot="theme-toggle-content"]')).not.toBeNull();
+    expect(iconToggleAfter?.querySelectorAll("svg")).toHaveLength(1);
+    expect(iconAfter?.getAttribute("data-icon")).toBe("moon");
+    expect(getComputedStyle(iconAfter!).inlineSize).toBe("14px");
+    expect(getComputedStyle(iconAfter!).blockSize).toBe("14px");
+    expect(textToggleAfter?.textContent).toBe("light");
+    expect(textToggleAfter?.getAttribute("data-theme-choice")).toBe("dark");
+    expect(textToggleAfter?.getAttribute("data-next-theme")).toBe("light");
+  });
+});

--- a/tests/browser/theme-toggle-visibility.test.tsx
+++ b/tests/browser/theme-toggle-visibility.test.tsx
@@ -23,6 +23,8 @@ describe("theme toggle visibility", () => {
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/theme-visibility");
     clearRoutes();
+    window.localStorage.removeItem("askr-theme");
+    window.localStorage.removeItem("askr-theme-toggle-visibility");
   });
 
   afterEach(() => {
@@ -33,13 +35,16 @@ describe("theme toggle visibility", () => {
     }
 
     clearRoutes();
+    window.localStorage.removeItem("askr-theme");
+    window.localStorage.removeItem("askr-theme-toggle-visibility");
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-theme-choice");
+    document.documentElement.style.removeProperty("--ak-theme-toggle-icon-size");
   });
 
   it("should keep toggle content visible after switching to dark mode", async () => {
     route("/theme-visibility", () => (
-      <ThemeProvider defaultTheme="light">
+      <ThemeProvider defaultTheme="light" storageKey="askr-theme-toggle-visibility">
         <Shell variant="topbar">
           <ShellNav>
             <Navbar aria-label="Theme visibility">
@@ -108,6 +113,9 @@ describe("theme toggle visibility", () => {
     expect(icon?.getAttribute("data-icon")).toBe("sun");
     expect(getComputedStyle(icon!).inlineSize).toBe("14px");
     expect(getComputedStyle(icon!).blockSize).toBe("14px");
+    document.documentElement.style.setProperty("--ak-theme-toggle-icon-size", "22px");
+    expect(getComputedStyle(icon!).inlineSize).toBe("22px");
+    expect(getComputedStyle(icon!).blockSize).toBe("22px");
     expect(textToggle?.textContent).toBe("dark");
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
 

--- a/tests/browser/theme-toggle-visibility.test.tsx
+++ b/tests/browser/theme-toggle-visibility.test.tsx
@@ -98,44 +98,48 @@ describe("theme toggle visibility", () => {
     await createSPA({ root: container!, manifest: getManifest() });
     await settle();
 
-    const toggles = [
-      ...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? []),
-    ] as HTMLButtonElement[];
-    const iconToggle = toggles[0];
-    const textToggle = toggles[1];
+    const toggles = [...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? [])] as [
+      HTMLButtonElement,
+      HTMLButtonElement,
+    ];
+    expect(toggles).toHaveLength(2);
+    const [iconToggle, textToggle] = toggles;
     const iconContent = iconToggle?.querySelector('[data-slot="theme-toggle-content"]');
-    const icon = iconToggle?.querySelector("svg") as SVGElement | null;
+    const icon = iconToggle?.querySelector("svg");
 
     expect(iconToggle).not.toBeNull();
     expect(textToggle).not.toBeNull();
+    expect(icon).not.toBeNull();
     expect(iconContent).not.toBeNull();
     expect(iconToggle?.querySelectorAll("svg")).toHaveLength(1);
     expect(icon?.getAttribute("data-icon")).toBe("sun");
-    expect(getComputedStyle(icon!).inlineSize).toBe("14px");
-    expect(getComputedStyle(icon!).blockSize).toBe("14px");
+    expect(getComputedStyle(icon as SVGElement).inlineSize).toBe("14px");
+    expect(getComputedStyle(icon as SVGElement).blockSize).toBe("14px");
     document.documentElement.style.setProperty("--ak-theme-toggle-icon-size", "22px");
-    expect(getComputedStyle(icon!).inlineSize).toBe("22px");
-    expect(getComputedStyle(icon!).blockSize).toBe("22px");
+    expect(getComputedStyle(icon as SVGElement).inlineSize).toBe("22px");
+    expect(getComputedStyle(icon as SVGElement).blockSize).toBe("22px");
     expect(textToggle?.textContent).toBe("dark");
     expect(document.documentElement.getAttribute("data-theme")).toBe("light");
 
     iconToggle?.click();
     await settle();
 
-    const togglesAfter = [
-      ...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? []),
-    ] as HTMLButtonElement[];
-    const iconToggleAfter = togglesAfter[0];
-    const textToggleAfter = togglesAfter[1];
-    const iconAfter = iconToggleAfter?.querySelector("svg") as SVGElement | null;
+    const togglesAfter = [...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? [])] as [
+      HTMLButtonElement,
+      HTMLButtonElement,
+    ];
+    expect(togglesAfter).toHaveLength(2);
+    const [iconToggleAfter, textToggleAfter] = togglesAfter;
+    const iconAfter = iconToggleAfter?.querySelector("svg");
 
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(iconToggleAfter?.getAttribute("data-theme-choice")).toBe("dark");
     expect(iconToggleAfter?.querySelector('[data-slot="theme-toggle-content"]')).not.toBeNull();
     expect(iconToggleAfter?.querySelectorAll("svg")).toHaveLength(1);
+    expect(iconAfter).not.toBeNull();
     expect(iconAfter?.getAttribute("data-icon")).toBe("moon");
-    expect(getComputedStyle(iconAfter!).inlineSize).toBe("22px");
-    expect(getComputedStyle(iconAfter!).blockSize).toBe("22px");
+    expect(getComputedStyle(iconAfter as SVGElement).inlineSize).toBe("22px");
+    expect(getComputedStyle(iconAfter as SVGElement).blockSize).toBe("22px");
     expect(textToggleAfter?.textContent).toBe("light");
     expect(textToggleAfter?.getAttribute("data-theme-choice")).toBe("dark");
     expect(textToggleAfter?.getAttribute("data-next-theme")).toBe("light");

--- a/tests/browser/theme-toggle-visibility.test.tsx
+++ b/tests/browser/theme-toggle-visibility.test.tsx
@@ -134,8 +134,8 @@ describe("theme toggle visibility", () => {
     expect(iconToggleAfter?.querySelector('[data-slot="theme-toggle-content"]')).not.toBeNull();
     expect(iconToggleAfter?.querySelectorAll("svg")).toHaveLength(1);
     expect(iconAfter?.getAttribute("data-icon")).toBe("moon");
-    expect(getComputedStyle(iconAfter!).inlineSize).toBe("14px");
-    expect(getComputedStyle(iconAfter!).blockSize).toBe("14px");
+    expect(getComputedStyle(iconAfter!).inlineSize).toBe("22px");
+    expect(getComputedStyle(iconAfter!).blockSize).toBe("22px");
     expect(textToggleAfter?.textContent).toBe("light");
     expect(textToggleAfter?.getAttribute("data-theme-choice")).toBe("dark");
     expect(textToggleAfter?.getAttribute("data-next-theme")).toBe("light");


### PR DESCRIPTION
Fixes #2

## What changed
- Wrap ThemeToggle content in a dedicated `data-slot="theme-toggle-content"` span so icon and text content have a stable layout hook.
- Add matching button-slot CSS for nested icon sizing in the default theme and template theme.
- Add a browser regression test that exercises ThemeToggle inside a shell/navbar composition and verifies the content stays visible across a light-to-dark switch.

## Verification
- `npm run test:browser -- --run tests/browser/theme-toggle-visibility.test.tsx tests/browser/theme-route-persistence.test.tsx`
- `npm run test:jsdom -- --run tests/jsdom/theme-contract.test.tsx tests/jsdom/theme-route-persistence.test.tsx`
- `npm run test:unit -- --run tests/unit/theme-toggle.test.ts tests/unit/theme-contract.test.tsx tests/unit/package-surface.test.ts`