### PR TITLE
test: cover themed Toast and Portal coexistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,9 +82,9 @@
       "license": "MIT"
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.54.tgz",
-      "integrity": "sha512-a1K94auZhtx+1jtUZbbkfFm302RqtVicJhisq9a8I9EV3UphAEAXOWQ7YVHtseClVby+uJnVI1kGdjHp3YjgDw==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.59.tgz",
+      "integrity": "sha512-+vFr+/x00rQKJlOXPFKTi9TonrGg8ZvNNKkemhM3kKA6rcXkgsFa2+vQnSfg64eRakGaZ1nAtf9f5MFE4kQIwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/tests/browser/toast-portal.test.tsx
+++ b/tests/browser/toast-portal.test.tsx
@@ -12,6 +12,7 @@ async function settle(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => requestAnimationFrame(resolve));
 }
 
 function waitForScheduler(): Promise<void> {
@@ -56,6 +57,6 @@ describe("themed Toast and default Portal", () => {
     await waitForScheduler();
 
     expect(document.body.textContent).toContain("Sidebar content");
-    expect(container?.querySelector('[data-toast="true"]')).toBeNull();
+    expect(document.body.querySelector('[data-slot="toast"]')).toBeNull();
   });
 });

--- a/tests/browser/toast-portal.test.tsx
+++ b/tests/browser/toast-portal.test.tsx
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { cleanupApp, createSPA } from "@askrjs/askr/boot";
+import { Portal } from "@askrjs/askr/foundations";
+import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
+
+import { Toast, ToastHost, ToastTitle, ToastViewport } from "../../src/components";
+
+import "../../src/themes/default/index.css";
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("themed Toast and default Portal", () => {
+  let container: HTMLDivElement | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    clearRoutes();
+    window.history.replaceState({}, "", "/toast-portal");
+  });
+
+  afterEach(() => {
+    if (container) {
+      cleanupApp(container);
+      container.remove();
+      container = undefined;
+    }
+
+    clearRoutes();
+  });
+
+  it("should mount a closed Toast beside portaled content without an update loop", async () => {
+    route("/toast-portal", () => (
+      <ToastHost>
+        <Portal>
+          <div>Sidebar content</div>
+        </Portal>
+        <ToastViewport />
+        <Toast open={false}>
+          <ToastTitle>Validation result</ToastTitle>
+        </Toast>
+      </ToastHost>
+    ));
+
+    await createSPA({ root: container!, manifest: getManifest() });
+    await settle();
+
+    expect(document.body.textContent).toContain("Sidebar content");
+    expect(container?.querySelector('[data-toast-root="true"]')).toBeNull();
+  });
+});

--- a/tests/browser/toast-portal.test.tsx
+++ b/tests/browser/toast-portal.test.tsx
@@ -14,6 +14,10 @@ async function settle(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function waitForScheduler(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 20));
+}
+
 describe("themed Toast and default Portal", () => {
   let container: HTMLDivElement | undefined;
 
@@ -49,8 +53,9 @@ describe("themed Toast and default Portal", () => {
 
     await createSPA({ root: container!, manifest: getManifest() });
     await settle();
+    await waitForScheduler();
 
     expect(document.body.textContent).toContain("Sidebar content");
-    expect(container?.querySelector('[data-toast-root="true"]')).toBeNull();
+    expect(container?.querySelector('[data-toast="true"]')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- add a browser regression through the themed `components` entrypoint
- exercise a closed Toast beside default Portal content in a real `createSPA` route
- refresh the lockfile to the reported `@askrjs/askr` 0.0.59 runtime while preserving the declared peer-compatible range

The reported reproduction passes on the current published package set, so the regression proves the issue has already been resolved and no theme-local workaround is needed.

Closes #13

## Validation

- `npm run check`
- `npm run fmt`