### PR TITLE
fix(card): allow semantic title headings

### DIFF
--- a/THEMING.md
+++ b/THEMING.md
@@ -37,6 +37,15 @@ Style override:
 }
 ```
 
+Card titles default to `h3`. Choose `titleAs` from the surrounding document
+hierarchy; use `h1` when the card title is the page title, or the next logical
+level beneath an existing heading:
+
+```tsx
+<CardTitle titleAs="h1">Sign in</CardTitle>
+<CardTitle titleAs="h2">Live sessions</CardTitle>
+```
+
 Icon override:
 
 ```css

--- a/src/components/card/card.tsx
+++ b/src/components/card/card.tsx
@@ -41,14 +41,14 @@ export function CardHeader(props: CardHeaderProps): JSX.Element {
 }
 
 export function CardTitle(props: CardTitleProps): JSX.Element {
-  const { children, class: className, ref, ...rest } = props;
+  const { children, class: className, ref, titleAs: TitleTag = "h3", ...rest } = props;
   const finalProps = mergeProps(rest, {
     ref,
     class: classes("card-title", className),
     "data-slot": "card-title",
   });
 
-  return <h3 {...finalProps}>{children}</h3>;
+  return <TitleTag {...finalProps}>{children}</TitleTag>;
 }
 
 export function CardDescription(props: CardDescriptionProps): JSX.Element {

--- a/src/components/card/card.types.ts
+++ b/src/components/card/card.types.ts
@@ -1,6 +1,7 @@
 import type { Ref } from "@askrjs/askr/foundations/utilities";
 
 export type CardVariant = "default" | "raised";
+export type CardTitleHeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
 
 type DivProps = Omit<JSX.IntrinsicElements["div"], "children" | "ref">;
 type HeadingProps = Omit<JSX.IntrinsicElements["h3"], "children" | "ref">;
@@ -19,6 +20,8 @@ export type CardHeaderProps = DivProps & {
 
 export type CardTitleProps = HeadingProps & {
   children?: unknown;
+  /** Choose the level that follows the surrounding document hierarchy. */
+  titleAs?: CardTitleHeadingTag;
   ref?: Ref<HTMLHeadingElement>;
 };
 

--- a/src/components/card/index.ts
+++ b/src/components/card/index.ts
@@ -16,5 +16,6 @@ export type {
   CardHeaderProps,
   CardProps,
   CardTitleProps,
+  CardTitleHeadingTag,
   CardVariant,
 } from "./card.types";

--- a/tests/browser/card-title.test.tsx
+++ b/tests/browser/card-title.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+
+import { cleanupApp, createIsland } from "@askrjs/askr/boot";
+
+import { CardTitle } from "../../src/components/card";
+
+describe("card title semantics", () => {
+  let container: HTMLDivElement | undefined;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    if (container) {
+      cleanupApp(container);
+      container.remove();
+      container = undefined;
+    }
+  });
+
+  it("should preserve title styling and slots across heading levels", () => {
+    createIsland({
+      root: container!,
+      component: () => (
+        <main>
+          <CardTitle>Default</CardTitle>
+          <CardTitle titleAs="h1" class="page-title">
+            Page
+          </CardTitle>
+          <CardTitle titleAs="h6">Nested</CardTitle>
+        </main>
+      ),
+    });
+
+    const titles = container!.querySelectorAll('[data-slot="card-title"]');
+    expect(Array.from(titles, (title) => title.tagName)).toEqual(["H3", "H1", "H6"]);
+    expect(titles[1]?.classList.contains("card-title")).toBe(true);
+    expect(titles[1]?.classList.contains("page-title")).toBe(true);
+  });
+});

--- a/tests/unit/card-components.test.ts
+++ b/tests/unit/card-components.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { Card } from "../../src/components/card";
+import { Card, CardTitle } from "../../src/components/card";
 import { Card as DefaultCard } from "../../src/surfaces";
 
 describe("theme card components", () => {
@@ -12,5 +12,11 @@ describe("theme card components", () => {
   it("should expose a card root component", () => {
     expect(typeof DefaultCard).toBe("function");
     expect(DefaultCard({ children: "body", variant: "raised" })).toBeTruthy();
+  });
+
+  it("should select the requested semantic heading for card titles", () => {
+    expect(CardTitle({ children: "Default" }).type).toBe("h3");
+    expect(CardTitle({ children: "Page", titleAs: "h1" }).type).toBe("h1");
+    expect(CardTitle({ children: "Nested", titleAs: "h6" }).type).toBe("h6");
   });
 });


### PR DESCRIPTION
Closes #15.

## Summary
- add `titleAs` support for `h1` through `h6`
- preserve `h3` as the default and keep the heading ref contract
- retain the `card-title` class and data slot at every level
- document choosing a level from the surrounding heading hierarchy

## Validation
- `npm run fmt`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run test:publint`
- `npm run test:installed`
- `npm run pack:check`