### PR TITLE
fix: isolate theme styles by CSP nonce

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @smiggleworth

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: "lts/*"
           cache: npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,10 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@main
+    uses: askrjs/actions/.github/workflows/publish-package.yml@cfbfac63066d778fa1fa99247f6af43515155e4f
     with:
       install-playwright: true
     permissions:
       contents: write
       id-token: write
       packages: read
-    secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@cfbfac63066d778fa1fa99247f6af43515155e4f
+    uses: askrjs/actions/.github/workflows/publish-package.yml@614b9e344983ad2100563c5f36f94d774d3ba6bd
     with:
       install-playwright: true
     permissions:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@askrjs/askr": ">=0.0.52 <0.1.0",
+        "@askrjs/askr": ">=0.0.64 <0.1.0",
         "@askrjs/ui": ">=0.0.12 <0.1.0",
         "@askrjs/vite": ">=0.0.5 <0.1.0",
         "@tsdown/css": "0.22.8",
@@ -26,7 +26,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@askrjs/askr": ">=0.0.52 <0.1.0",
+        "@askrjs/askr": ">=0.0.64 <0.1.0",
         "@askrjs/ui": ">=0.0.12 <0.1.0"
       }
     },
@@ -82,9 +82,9 @@
       "license": "MIT"
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.59",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.59.tgz",
-      "integrity": "sha512-+vFr+/x00rQKJlOXPFKTi9TonrGg8ZvNNKkemhM3kKA6rcXkgsFa2+vQnSfg64eRakGaZ1nAtf9f5MFE4kQIwQ==",
+      "version": "0.0.64",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.64.tgz",
+      "integrity": "sha512-L5uCEbtfKHj0VSa/TI2+nPWpYuOUf0ttMOvSgTiNu8DLXpP4Xd3sFniNJ0a67EfTfIOu4H7hFXzi3PzroK7Y1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.52 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "test:checks": "vp test run -c vitest.test.checks.config.ts"
   },
   "devDependencies": {
-    "@askrjs/askr": ">=0.0.52 <0.1.0",
+    "@askrjs/askr": ">=0.0.64 <0.1.0",
     "@askrjs/ui": ">=0.0.12 <0.1.0",
     "@askrjs/vite": ">=0.0.5 <0.1.0",
     "@tsdown/css": "0.22.8",
@@ -342,7 +342,7 @@
     "vite-plus": "^0.2.4"
   },
   "peerDependencies": {
-    "@askrjs/askr": ">=0.0.52 <0.1.0",
+    "@askrjs/askr": ">=0.0.64 <0.1.0",
     "@askrjs/ui": ">=0.0.12 <0.1.0"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",

--- a/src/components/_internal/pathname.ts
+++ b/src/components/_internal/pathname.ts
@@ -6,6 +6,17 @@ function getWindowLocation(): Location | null {
   return typeof window === "undefined" ? null : window.location;
 }
 
+export function assertSafeNavigationHref(href: string): void {
+  const trimmed = href.trim();
+  if (!trimmed || trimmed !== href)
+    throw new TypeError("Navigation href must be a non-empty canonical URL.");
+  const scheme = /^([a-z][a-z\d+.-]*):/iu.exec(trimmed)?.[1]?.toLowerCase();
+  if (scheme && !["http", "https", "mailto", "tel"].includes(scheme))
+    throw new TypeError(`Navigation URL scheme is not allowed: ${scheme}`);
+  if ([...trimmed].some((character) => character.charCodeAt(0) <= 31))
+    throw new TypeError("Navigation href must not contain control characters.");
+}
+
 export function resolvePathname(href: string): string | null {
   if (href.startsWith("#")) {
     return null;

--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -63,7 +63,7 @@ const STYLE_CLASS_PREFIX = "ak-style-";
 const styleClassCache = new Map<string, string>();
 type StyleRegistry = {
   element: HTMLStyleElement;
-  rules: Map<string, string>;
+  rules: Map<string, { className: string; rule: string }>;
 };
 const registries = new WeakMap<Document, Map<string, StyleRegistry>>();
 const MAX_STYLE_RULES = 512;
@@ -85,7 +85,7 @@ function ensureStyleRegistry(nonce: string | undefined): StyleRegistry | null {
   styleElement.setAttribute(STYLE_REGISTRY_ATTR, "true");
   if (nonce !== undefined) styleElement.nonce = nonce;
   (document.head ?? document.documentElement).append(styleElement);
-  const registry = { element: styleElement, rules: new Map<string, string>() };
+  const registry: StyleRegistry = { element: styleElement, rules: new Map() };
   documentRegistries.set(key, registry);
   return registry;
 }
@@ -100,6 +100,11 @@ export function styleDeclarationsToClass(declarations: string | undefined): stri
   const normalized = normalizeDeclarations(declarations);
   if (!normalized) return undefined;
 
+  const nonce = cspNonce();
+  const registry = ensureStyleRegistry(nonce);
+  const registered = registry?.rules.get(normalized);
+  if (registered) return registered.className;
+
   let className = styleClassCache.get(normalized);
   if (className === undefined) {
     className = `${STYLE_CLASS_PREFIX}${++nextStyleClassId}`;
@@ -110,18 +115,16 @@ export function styleDeclarationsToClass(declarations: string | undefined): stri
     styleClassCache.set(normalized, className);
   }
 
-  const nonce = cspNonce();
-  const registry = ensureStyleRegistry(nonce);
-  if (registry && !registry.rules.has(normalized)) {
+  if (registry) {
     const styleElement = registry.element;
     if (styleElement) {
+      if (registry.rules.size >= MAX_STYLE_RULES)
+        throw new RangeError("Theme style registry capacity exceeded.");
       const rule = `.${className}{${normalized}}`;
-      if (registry.rules.size >= MAX_STYLE_RULES) {
-        const oldest = registry.rules.keys().next().value as string | undefined;
-        if (oldest !== undefined) registry.rules.delete(oldest);
-      }
-      registry.rules.set(normalized, rule);
-      styleElement.textContent = Array.from(registry.rules.values()).join("\n");
+      registry.rules.set(normalized, { className, rule });
+      styleElement.textContent = Array.from(registry.rules.values(), (entry) => entry.rule).join(
+        "\n",
+      );
     }
   }
 

--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -1,3 +1,5 @@
+import { cspNonce } from "@askrjs/askr";
+
 const cssPropertyNameCache = new Map<string, string>();
 
 function cssPropertyName(name: string): string {
@@ -59,23 +61,33 @@ const STYLE_REGISTRY_ATTR = "data-askr-style-registry";
 const STYLE_CLASS_PREFIX = "ak-style-";
 
 const styleClassCache = new Map<string, string>();
-const registeredDeclarations = new Set<string>();
+type StyleRegistry = {
+  element: HTMLStyleElement;
+  rules: Map<string, string>;
+};
+const registries = new WeakMap<Document, Map<string, StyleRegistry>>();
+const MAX_STYLE_RULES = 512;
 
 let nextStyleClassId = 0;
 
-function ensureStyleElement(): HTMLStyleElement | null {
+function ensureStyleRegistry(nonce: string | undefined): StyleRegistry | null {
   if (typeof document === "undefined") return null;
-
-  const existing = document.querySelector(`style[${STYLE_REGISTRY_ATTR}]`);
-  if (existing instanceof HTMLStyleElement) {
-    return existing;
+  const key = nonce ?? "";
+  let documentRegistries = registries.get(document);
+  if (!documentRegistries) {
+    documentRegistries = new Map();
+    registries.set(document, documentRegistries);
   }
+  const current = documentRegistries.get(key);
+  if (current?.element.isConnected) return current;
 
   const styleElement = document.createElement("style");
   styleElement.setAttribute(STYLE_REGISTRY_ATTR, "true");
+  if (nonce !== undefined) styleElement.nonce = nonce;
   (document.head ?? document.documentElement).append(styleElement);
-
-  return styleElement;
+  const registry = { element: styleElement, rules: new Map<string, string>() };
+  documentRegistries.set(key, registry);
+  return registry;
 }
 
 function normalizeDeclarations(declarations: string): string {
@@ -91,15 +103,25 @@ export function styleDeclarationsToClass(declarations: string | undefined): stri
   let className = styleClassCache.get(normalized);
   if (className === undefined) {
     className = `${STYLE_CLASS_PREFIX}${++nextStyleClassId}`;
+    if (styleClassCache.size >= MAX_STYLE_RULES) {
+      const oldest = styleClassCache.keys().next().value as string | undefined;
+      if (oldest !== undefined) styleClassCache.delete(oldest);
+    }
     styleClassCache.set(normalized, className);
   }
 
-  if (!registeredDeclarations.has(normalized)) {
-    const styleElement = ensureStyleElement();
+  const nonce = cspNonce();
+  const registry = ensureStyleRegistry(nonce);
+  if (registry && !registry.rules.has(normalized)) {
+    const styleElement = registry.element;
     if (styleElement) {
       const rule = `.${className}{${normalized}}`;
-      styleElement.textContent = `${styleElement.textContent ?? ""}\n${rule}`;
-      registeredDeclarations.add(normalized);
+      if (registry.rules.size >= MAX_STYLE_RULES) {
+        const oldest = registry.rules.keys().next().value as string | undefined;
+        if (oldest !== undefined) registry.rules.delete(oldest);
+      }
+      registry.rules.set(normalized, rule);
+      styleElement.textContent = Array.from(registry.rules.values()).join("\n");
     }
   }
 

--- a/src/components/nav/nav.tsx
+++ b/src/components/nav/nav.tsx
@@ -4,7 +4,7 @@ import { Block } from "../block";
 import { classes } from "../_internal/classes";
 import { mergeProps } from "../_internal/merge-props";
 import { intrinsicElement } from "../_internal/jsx";
-import { resolvePathname } from "../_internal/pathname";
+import { assertSafeNavigationHref, resolvePathname } from "../_internal/pathname";
 import type {
   NavItemAsChildProps,
   NavItemProps,
@@ -114,6 +114,7 @@ function renderRoutedLink(
   if (!href) {
     throw new Error("Nav link requires href or to.");
   }
+  assertSafeNavigationHref(href);
   const inheritedSlot =
     options.inheritSlot && typeof (rest as Record<string, unknown>)["data-slot"] === "string"
       ? String((rest as Record<string, unknown>)["data-slot"])

--- a/tests/browser/csp-nonce.test.tsx
+++ b/tests/browser/csp-nonce.test.tsx
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import { cleanupApp, createIsland } from "@askrjs/askr/boot";
+import { Block } from "../../src/core";
+
+const roots: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    cleanupApp(root);
+    root.remove();
+  }
+});
+
+describe("theme CSP nonce", () => {
+  it("should create separate nonced style registries", () => {
+    const first = "MDEyMzQ1Njc4OWFiY2RlZg";
+    const second = "ZmVkY2JhOTg3NjU0MzIxMA";
+    for (const [nonce, padding] of [
+      [first, "sm"],
+      [second, "lg"],
+    ] as const) {
+      const root = document.createElement("div");
+      document.body.append(root);
+      roots.push(root);
+      createIsland({
+        root,
+        cspNonce: nonce,
+        component: () => <Block padding={padding}>content</Block>,
+      });
+    }
+    const styles = Array.from(
+      document.querySelectorAll<HTMLStyleElement>("style[data-askr-style-registry]"),
+    );
+    expect(styles.some((style) => style.nonce === first)).toBe(true);
+    expect(styles.some((style) => style.nonce === second)).toBe(true);
+  });
+});

--- a/tests/unit/navigation-contracts.test.ts
+++ b/tests/unit/navigation-contracts.test.ts
@@ -128,4 +128,13 @@ describe("navigation contracts", () => {
     expect(sidebar.props.as).toBe("aside");
     expect(sidebar.props["data-slot"]).toBe("sidebar");
   });
+
+  it.each(["javascript:alert(1)", "data:text/html,pwned", "vbscript:msgbox(1)"])(
+    "should reject executable NavLink URL scheme %s",
+    (href) => {
+      expect(() => NavLink({ href, children: "Unsafe" })).toThrow(
+        "Navigation URL scheme is not allowed",
+      );
+    },
+  );
 });


### PR DESCRIPTION
Scopes theme style registries by document and CSP nonce, captures navigation state safely, pins the protected publishing workflow, and prepares 0.0.15. Requires @askrjs/askr 0.0.64+.\n\nThe package-native release gate passes against the published registry artifact.