### PR TITLE
fix: use explicit route registries in themes tests

### DIFF
--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -108,10 +108,6 @@ export function styleDeclarationsToClass(declarations: string | undefined): stri
   let className = styleClassCache.get(normalized);
   if (className === undefined) {
     className = `${STYLE_CLASS_PREFIX}${++nextStyleClassId}`;
-    if (styleClassCache.size >= MAX_STYLE_RULES) {
-      const oldest = styleClassCache.keys().next().value as string | undefined;
-      if (oldest !== undefined) styleClassCache.delete(oldest);
-    }
     styleClassCache.set(normalized, className);
   }
 
@@ -122,9 +118,7 @@ export function styleDeclarationsToClass(declarations: string | undefined): stri
         throw new RangeError("Theme style registry capacity exceeded.");
       const rule = `.${className}{${normalized}}`;
       registry.rules.set(normalized, { className, rule });
-      styleElement.textContent = Array.from(registry.rules.values(), (entry) => entry.rule).join(
-        "\n",
-      );
+      styleElement.append(rule, "\n");
     }
   }
 

--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -66,6 +66,7 @@ type StyleRegistry = {
   rules: Map<string, { className: string; rule: string }>;
 };
 const registries = new WeakMap<Document, Map<string, StyleRegistry>>();
+const MAX_STYLE_RULES = 512;
 
 let nextStyleClassId = 0;
 

--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -66,7 +66,6 @@ type StyleRegistry = {
   rules: Map<string, { className: string; rule: string }>;
 };
 const registries = new WeakMap<Document, Map<string, StyleRegistry>>();
-const MAX_STYLE_RULES = 512;
 
 let nextStyleClassId = 0;
 

--- a/tests/browser/dialog-theme.test.tsx
+++ b/tests/browser/dialog-theme.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -109,7 +109,7 @@ describe("dialog theme overflow regression", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
-    clearRoutes();
+    resetTestRoutes();
     innerWidthSpy = vi.spyOn(window, "innerWidth", "get");
     innerHeightSpy = vi.spyOn(window, "innerHeight", "get");
     innerWidthSpy.mockReturnValue(1200);
@@ -125,7 +125,7 @@ describe("dialog theme overflow regression", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
     innerWidthSpy = undefined;
     innerHeightSpy = undefined;
   });
@@ -133,7 +133,7 @@ describe("dialog theme overflow regression", () => {
   it("should keep themed Dialog content inside viewport padding at 390 x 844", async () => {
     window.history.replaceState({}, "", "/dialog-theme");
 
-    route("/dialog-theme", () => (
+    testRoute("/dialog-theme", () => (
       <Dialog>
         <DialogTrigger>Open dialog</DialogTrigger>
         <DialogPortal>
@@ -149,7 +149,7 @@ describe("dialog theme overflow regression", () => {
     ));
 
     setViewport(390, 844);
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const trigger = container?.querySelector(
@@ -169,7 +169,7 @@ describe("dialog theme overflow regression", () => {
   it("should keep themed AlertDialog content inside viewport padding at 390 x 844", async () => {
     window.history.replaceState({}, "", "/alert-dialog-theme");
 
-    route("/alert-dialog-theme", () => (
+    testRoute("/alert-dialog-theme", () => (
       <AlertDialog>
         <AlertDialogTrigger>Open alert</AlertDialogTrigger>
         <AlertDialogPortal>
@@ -185,7 +185,7 @@ describe("dialog theme overflow regression", () => {
     ));
 
     setViewport(390, 844);
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const trigger = container?.querySelector(

--- a/tests/browser/navbar-link.test.tsx
+++ b/tests/browser/navbar-link.test.tsx
@@ -2,7 +2,6 @@ import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../ro
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import {} from "@askrjs/askr/router";
 
 import { NavLink, Navbar } from "../../src/core";
 

--- a/tests/browser/navbar-link.test.tsx
+++ b/tests/browser/navbar-link.test.tsx
@@ -1,7 +1,8 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, group, route } from "@askrjs/askr/router";
+import {} from "@askrjs/askr/router";
 
 import { NavLink, Navbar } from "../../src/core";
 
@@ -17,7 +18,7 @@ describe("navbar link browser smoke", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -27,7 +28,7 @@ describe("navbar link browser smoke", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should updates active NavLink state across client-side navigation inside a persistent layout", async () => {
@@ -45,14 +46,14 @@ describe("navbar link browser smoke", () => {
       );
     }
 
-    group({ layout: DocsLayout }, () => {
-      route("/docs", () => "Docs home");
-      route("/docs/about", () => "Docs about");
+    testGroup({ layout: DocsLayout }, () => {
+      testRoute("/docs", () => "Docs home");
+      testRoute("/docs/about", () => "Docs about");
     });
 
     window.history.replaceState({}, "", "/docs");
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     let overviewLink = container?.querySelector('a[href="/docs"]') as HTMLAnchorElement | null;

--- a/tests/browser/navbar.test.tsx
+++ b/tests/browser/navbar.test.tsx
@@ -1,7 +1,8 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, Link, route } from "@askrjs/askr/router";
+import { Link } from "@askrjs/askr/router";
 
 import {
   Block,
@@ -48,7 +49,7 @@ describe("navbar browser smoke", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/docs");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -58,11 +59,11 @@ describe("navbar browser smoke", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should renders semantic navbar structure with Block layout styles", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <Header sticky>
         <Container>
           <Block direction="row" align="center" justify="between" paddingY="md">
@@ -79,9 +80,9 @@ describe("navbar browser smoke", () => {
         </Container>
       </Header>
     ));
-    route("/docs/components", () => <div id="page">Components</div>);
+    testRoute("/docs/components", () => <div id="page">Components</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const header = container?.querySelector('[data-slot="header"]') as HTMLElement | null;
@@ -120,7 +121,7 @@ describe("navbar browser smoke", () => {
   });
 
   it("should centers primary routes between brand and end actions", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <Header sticky>
         <Container>
           <Navbar aria-label="App navigation">
@@ -142,7 +143,7 @@ describe("navbar browser smoke", () => {
       </Header>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const navbar = container?.querySelector('[data-slot="navbar"]') as HTMLElement | null;
@@ -173,7 +174,7 @@ describe("navbar browser smoke", () => {
   it("should prevent brand content from overlapping centered routes", async () => {
     setViewport(390);
 
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <div style={{ width: "390px" }}>
         <Navbar aria-label="App navigation">
           <NavBrand asChild>
@@ -196,7 +197,7 @@ describe("navbar browser smoke", () => {
       </div>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const brand = container?.querySelector('[data-slot="nav-brand"]') as HTMLElement | null;
@@ -223,19 +224,19 @@ describe("navbar browser smoke", () => {
       </Navbar>
     );
 
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <>
         <ResponsiveNav />
         <div id="page">Docs</div>
       </>
     ));
-    route("/docs/components", () => (
+    testRoute("/docs/components", () => (
       <>
         <ResponsiveNav />
         <div id="page">Components</div>
       </>
     ));
-    route("/", () => (
+    testRoute("/", () => (
       <>
         <ResponsiveNav />
         <div id="page">Home</div>
@@ -243,7 +244,7 @@ describe("navbar browser smoke", () => {
     ));
 
     setViewport(375);
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const navbar = container?.querySelector('[data-slot="navbar"]') as HTMLElement | null;
@@ -292,7 +293,7 @@ describe("navbar browser smoke", () => {
   });
 
   it("should opens NavDropdown with route-aware NavLink children", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <Navbar aria-label="Dropdown docs navigation">
         <NavBrand as="a" href="/">
           Askr
@@ -304,9 +305,9 @@ describe("navbar browser smoke", () => {
         </NavDropdown>
       </Navbar>
     ));
-    route("/docs/components", () => <div id="page">Components</div>);
+    testRoute("/docs/components", () => <div id="page">Components</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const trigger = container?.querySelector(

--- a/tests/browser/overlays-navbar-sidebar.test.tsx
+++ b/tests/browser/overlays-navbar-sidebar.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { Block, Main, NavGroup, NavLink, Navbar, Sidebar } from "../../src/core";
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "../../src/overlays";
@@ -28,7 +28,7 @@ describe("navbar and sidebar overlay recipes", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/docs");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -38,11 +38,11 @@ describe("navbar and sidebar overlay recipes", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should compose real Dropdown primitives inside navbar and sidebar recipes", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <Block minHeight="screen" direction="row">
         <Sidebar aria-label="Sidebar navigation">
           <NavGroup title="Workspace">
@@ -74,10 +74,10 @@ describe("navbar and sidebar overlay recipes", () => {
         </Main>
       </Block>
     ));
-    route("/docs/audit", () => <div id="page">Audit log</div>);
-    route("/docs/components", () => <div id="page">Components</div>);
+    testRoute("/docs/audit", () => <div id="page">Audit log</div>);
+    testRoute("/docs/components", () => <div id="page">Components</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const productTrigger = container?.querySelector(
@@ -108,8 +108,8 @@ describe("navbar and sidebar overlay recipes", () => {
 
     cleanupApp(container!);
     window.history.replaceState({}, "", "/docs");
-    clearRoutes();
-    route("/docs", () => (
+    resetTestRoutes();
+    testRoute("/docs", () => (
       <Sidebar aria-label="Sidebar navigation">
         <NavGroup title="Workspace">
           <Dropdown id="sidebar-workspace-dropdown">
@@ -121,7 +121,7 @@ describe("navbar and sidebar overlay recipes", () => {
         </NavGroup>
       </Sidebar>
     ));
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const sidebarTrigger = container?.querySelector(

--- a/tests/browser/public-family-smoke.test.tsx
+++ b/tests/browser/public-family-smoke.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import {
   Button,
@@ -47,7 +47,7 @@ describe("public family browser smoke", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
-    clearRoutes();
+    resetTestRoutes();
     window.history.replaceState({}, "", "/families");
   });
 
@@ -58,11 +58,11 @@ describe("public family browser smoke", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should renders the remaining public families in a browser mount", async () => {
-    route("/families", () => (
+    testRoute("/families", () => (
       <Page>
         <Header sticky>
           <Container>
@@ -148,7 +148,7 @@ describe("public family browser smoke", () => {
       </Page>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     for (const slot of [
@@ -201,7 +201,7 @@ describe("public family browser smoke", () => {
   });
 
   it("should keep attached input groups on one row in constrained toolbar actions", async () => {
-    route("/families", () => (
+    testRoute("/families", () => (
       <Page>
         <Toolbar
           title="Event rows"
@@ -217,7 +217,7 @@ describe("public family browser smoke", () => {
       </Page>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const group = container?.querySelector('[data-slot="input-group"]') as HTMLElement | null;

--- a/tests/browser/sidebar.test.tsx
+++ b/tests/browser/sidebar.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { Block, Container, Main, NavGroup, NavLink, PageHeader, Sidebar } from "../../src/core";
 
@@ -25,7 +25,7 @@ describe("sidebar browser smoke", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/docs");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -35,11 +35,11 @@ describe("sidebar browser smoke", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should renders sidebar as a semantic Block preset beside main content", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <Block minHeight="screen" direction="row">
         <Sidebar aria-label="Workspace navigation">
           <strong>Askr</strong>
@@ -65,9 +65,9 @@ describe("sidebar browser smoke", () => {
         </Main>
       </Block>
     ));
-    route("/docs/components", () => <div id="page">Components</div>);
+    testRoute("/docs/components", () => <div id="page">Components</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const sidebar = container?.querySelector('[data-slot="sidebar"]') as HTMLElement | null;

--- a/tests/browser/spinner.test.tsx
+++ b/tests/browser/spinner.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { Spinner } from "../../src/surfaces";
 
@@ -17,7 +17,7 @@ describe("spinner browser smoke", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/status");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -27,17 +27,17 @@ describe("spinner browser smoke", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should renders spinner sizing", async () => {
-    route("/status", () => (
+    testRoute("/status", () => (
       <div>
         <Spinner label="Syncing" />
       </div>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const spinner = container?.querySelector('[data-slot="progress-circle"]') as HTMLElement | null;

--- a/tests/browser/table-theme.test.tsx
+++ b/tests/browser/table-theme.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 import {
   Table,
   TableBody,
@@ -25,7 +25,7 @@ describe("table theme smoke test", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/table");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -35,11 +35,11 @@ describe("table theme smoke test", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should styles the semantic table primitives through the default theme bundle", async () => {
-    route("/table", () => (
+    testRoute("/table", () => (
       <Table aria-label="Users">
         <TableHead>
           <TableRow>
@@ -56,7 +56,7 @@ describe("table theme smoke test", () => {
       </Table>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const table = container?.querySelector('[data-slot="table"]') as HTMLTableElement | null;

--- a/tests/browser/theme-route-persistence.test.tsx
+++ b/tests/browser/theme-route-persistence.test.tsx
@@ -1,8 +1,9 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
 import { createQuery } from "@askrjs/askr/data";
-import { clearRoutes, getManifest, group, navigate, route } from "@askrjs/askr/router";
+import { navigate } from "@askrjs/askr/router";
 
 import { Block, Container, Header, Main, NavGroup, Navbar } from "../../src/core";
 import { CAT_THEME_NAMES, CAT_THEME_OPTIONS, ThemeScope, ThemeToggle } from "../../src/theme";
@@ -21,7 +22,7 @@ describe("theme route persistence in the browser", () => {
     document.body.appendChild(container);
     window.localStorage.removeItem("askr-theme");
     window.history.replaceState({}, "", "/example");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -30,7 +31,7 @@ describe("theme route persistence in the browser", () => {
       container.remove();
       container = undefined;
     }
-    clearRoutes();
+    resetTestRoutes();
     window.localStorage.removeItem("askr-theme");
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-theme-choice");
@@ -46,12 +47,12 @@ describe("theme route persistence in the browser", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
-      route("/about", () => <div id="page">About</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
+      testRoute("/about", () => <div id="page">About</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
 
     expect(container.querySelector('[data-slot="theme-scope"]')).not.toBeNull();
     expect(document.documentElement.getAttribute("data-theme")).toBeNull();
@@ -119,12 +120,12 @@ describe("theme route persistence in the browser", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
-      route("/about", () => <div id="page">About</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
+      testRoute("/about", () => <div id="page">About</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
 
     expect(document.documentElement.getAttribute("data-theme")).toBeNull();
     expect(document.documentElement.getAttribute("data-theme-choice")).toBeNull();
@@ -217,12 +218,12 @@ describe("theme route persistence in the browser", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme-stall", () => <TopologyPage />);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme-stall", () => <TopologyPage />);
     });
 
     window.history.replaceState({}, "", "/theme-stall");
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getToggle = () =>

--- a/tests/browser/theme-toggle-visibility.test.tsx
+++ b/tests/browser/theme-toggle-visibility.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { Block, Container, Header, Main, NavGroup, Navbar } from "../../src/core";
 import { ThemeScope, ThemeToggle, type ThemeToggleRenderContext } from "../../src/theme";
@@ -21,7 +21,7 @@ describe("theme toggle visibility", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/theme-visibility");
-    clearRoutes();
+    resetTestRoutes();
     window.localStorage.removeItem("askr-theme");
     window.localStorage.removeItem("askr-theme-toggle-visibility");
   });
@@ -33,7 +33,7 @@ describe("theme toggle visibility", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
     window.localStorage.removeItem("askr-theme");
     window.localStorage.removeItem("askr-theme-toggle-visibility");
     document.documentElement.removeAttribute("data-theme");
@@ -42,7 +42,7 @@ describe("theme toggle visibility", () => {
   });
 
   it("should keep toggle content visible after switching to dark mode", async () => {
-    route("/theme-visibility", () => (
+    testRoute("/theme-visibility", () => (
       <ThemeScope defaultTheme="light" storageKey="askr-theme-toggle-visibility">
         <Header>
           <Container>
@@ -104,7 +104,7 @@ describe("theme toggle visibility", () => {
       </ThemeScope>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const toggles = [...(container?.querySelectorAll('[data-theme-control="toggle"]') ?? [])] as [

--- a/tests/browser/toast-portal.test.tsx
+++ b/tests/browser/toast-portal.test.tsx
@@ -1,8 +1,8 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
 import { Portal } from "@askrjs/askr/foundations";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { Toast, ToastHost, ToastTitle, ToastViewport } from "../../src/components";
 
@@ -25,7 +25,7 @@ describe("themed Toast and default Portal", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
-    clearRoutes();
+    resetTestRoutes();
     window.history.replaceState({}, "", "/toast-portal");
   });
 
@@ -36,11 +36,11 @@ describe("themed Toast and default Portal", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should mount a closed Toast beside portaled content without an update loop", async () => {
-    route("/toast-portal", () => (
+    testRoute("/toast-portal", () => (
       <ToastHost>
         <Portal>
           <div>Sidebar content</div>
@@ -52,7 +52,7 @@ describe("themed Toast and default Portal", () => {
       </ToastHost>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
     await waitForScheduler();
 

--- a/tests/jsdom/navbar-chrome.test.tsx
+++ b/tests/jsdom/navbar-chrome.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { NavBrand, NavDropdown, NavGroup, NavLink, Navbar, Sidebar } from "../../src/core";
 import { DropdownItem } from "../../src/overlays";
@@ -18,7 +18,7 @@ describe("navbar and sidebar chrome contracts", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
-    clearRoutes();
+    resetTestRoutes();
     window.history.replaceState({}, "", "/docs");
   });
 
@@ -29,11 +29,11 @@ describe("navbar and sidebar chrome contracts", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should renders the navbar and sidebar chrome with stable slots", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <>
         <Navbar aria-label="Docs navigation" id="docs-navbar">
           <a href="/">Askr</a>
@@ -56,7 +56,7 @@ describe("navbar and sidebar chrome contracts", () => {
       </>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const navbar = container?.querySelector('[data-slot="navbar"]') as HTMLElement | null;
@@ -85,7 +85,7 @@ describe("navbar and sidebar chrome contracts", () => {
   });
 
   it("should renders responsive navbar and nav dropdown slots", async () => {
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <Navbar aria-label="Responsive docs navigation" collapseAt="md" id="responsive-navbar">
         <NavBrand as="a" href="/">
           Askr
@@ -101,7 +101,7 @@ describe("navbar and sidebar chrome contracts", () => {
       </Navbar>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const navbar = container?.querySelector("#responsive-navbar") as HTMLElement | null;

--- a/tests/jsdom/navbar-link.test.tsx
+++ b/tests/jsdom/navbar-link.test.tsx
@@ -1,7 +1,8 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, Link, route } from "@askrjs/askr/router";
+import { Link } from "@askrjs/askr/router";
 
 import { Block, NavBrand, NavItem, NavLink, Navbar } from "../../src/core";
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "../../src/overlays";
@@ -32,10 +33,10 @@ function layout(page: string) {
 }
 
 function registerNavRoutes(): void {
-  route("/", () => layout("Home page"));
-  route("/docs", () => layout("Docs home"));
-  route("/docs/getting-started", () => layout("Getting started"));
-  route("/docs/components", () => layout("Components"));
+  testRoute("/", () => layout("Home page"));
+  testRoute("/docs", () => layout("Docs home"));
+  testRoute("/docs/getting-started", () => layout("Getting started"));
+  testRoute("/docs/components", () => layout("Components"));
 }
 
 describe("navbar link jsdom regression", () => {
@@ -44,7 +45,7 @@ describe("navbar link jsdom regression", () => {
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -54,14 +55,14 @@ describe("navbar link jsdom regression", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should marks the exact current route active", async () => {
     window.history.replaceState({}, "", "/docs");
     registerNavRoutes();
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const homeLink = container?.querySelector('a[href="/"]') as HTMLAnchorElement | null;
@@ -81,8 +82,8 @@ describe("navbar link jsdom regression", () => {
 
   it("should supports router Link as a NavBrand child", async () => {
     window.history.replaceState({}, "", "/docs");
-    route("/", () => <div id="page">Home page</div>);
-    route("/docs", () => (
+    testRoute("/", () => <div id="page">Home page</div>);
+    testRoute("/docs", () => (
       <>
         <Navbar aria-label="Primary">
           <NavBrand asChild>
@@ -96,7 +97,7 @@ describe("navbar link jsdom regression", () => {
       </>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const brand = container?.querySelector('[data-slot="nav-brand"]') as HTMLAnchorElement | null;
@@ -123,7 +124,7 @@ describe("navbar link jsdom regression", () => {
     window.history.replaceState({}, "", "/docs/getting-started");
     registerNavRoutes();
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const homeLink = container?.querySelector('a[href="/"]') as HTMLAnchorElement | null;
@@ -145,7 +146,7 @@ describe("navbar link jsdom regression", () => {
     window.history.replaceState({}, "", "/docs/components");
     registerNavRoutes();
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const docsLink = container?.querySelector('a[href="/docs"]') as HTMLAnchorElement | null;
@@ -164,7 +165,7 @@ describe("navbar link jsdom regression", () => {
     let clicks = 0;
 
     window.history.replaceState({}, "", "/");
-    route("/", () => (
+    testRoute("/", () => (
       <>
         <nav aria-label="Primary">
           <NavLink
@@ -179,9 +180,9 @@ describe("navbar link jsdom regression", () => {
         <div id="page">Home page</div>
       </>
     ));
-    route("/docs", () => <div id="page">Docs page</div>);
+    testRoute("/docs", () => <div id="page">Docs page</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const docsLink = container?.querySelector('a[href="/docs"]') as HTMLAnchorElement | null;
@@ -203,7 +204,7 @@ describe("navbar link jsdom regression", () => {
 
   it("should does not intercept modified clicks or explicit targets", async () => {
     window.history.replaceState({}, "", "/");
-    route("/", () => (
+    testRoute("/", () => (
       <nav aria-label="Primary">
         <NavLink href="/docs">Docs</NavLink>
         <NavLink href="/settings" target="_blank">
@@ -211,10 +212,10 @@ describe("navbar link jsdom regression", () => {
         </NavLink>
       </nav>
     ));
-    route("/docs", () => <div id="page">Docs page</div>);
-    route("/settings", () => <div id="page">Settings page</div>);
+    testRoute("/docs", () => <div id="page">Docs page</div>);
+    testRoute("/settings", () => <div id="page">Settings page</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const docsLink = container?.querySelector('a[href="/docs"]') as HTMLAnchorElement | null;
@@ -249,13 +250,13 @@ describe("navbar link jsdom regression", () => {
     let wasDefaultPreventedByNavLink: boolean | undefined;
 
     window.history.replaceState({}, "", "/");
-    route("/", () => (
+    testRoute("/", () => (
       <nav aria-label="Primary">
         <NavLink href="https://example.com/docs">External docs</NavLink>
       </nav>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const externalLink = container?.querySelector(
@@ -286,13 +287,13 @@ describe("navbar link jsdom regression", () => {
     let wasDefaultPreventedByNavLink: boolean | undefined;
 
     window.history.replaceState({}, "", "/docs");
-    route("/docs", () => (
+    testRoute("/docs", () => (
       <nav aria-label="Primary">
         <NavLink href="#api">API</NavLink>
       </nav>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const hashLink = container?.querySelector('a[href="#api"]') as HTMLAnchorElement | null;
@@ -319,7 +320,7 @@ describe("navbar link jsdom regression", () => {
 
   it("should preserves route behavior through DropdownItem asChild with NavLink", async () => {
     window.history.replaceState({}, "", "/");
-    route("/", () => (
+    testRoute("/", () => (
       <nav aria-label="Primary">
         <Dropdown id="route-dropdown" defaultOpen>
           <DropdownTrigger>Workspace</DropdownTrigger>
@@ -334,9 +335,9 @@ describe("navbar link jsdom regression", () => {
         </Dropdown>
       </nav>
     ));
-    route("/docs", () => <div id="page">Docs page</div>);
+    testRoute("/docs", () => <div id="page">Docs page</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const docsLink = document.body.querySelector(
@@ -371,7 +372,7 @@ describe("navbar link jsdom regression", () => {
     let modifiedWasNotCancelled: boolean | undefined;
 
     window.history.replaceState({}, "", "/");
-    route("/", () => (
+    testRoute("/", () => (
       <nav aria-label="Primary">
         <Dropdown id="native-dropdown" defaultOpen>
           <DropdownTrigger>Workspace</DropdownTrigger>
@@ -386,9 +387,9 @@ describe("navbar link jsdom regression", () => {
         </Dropdown>
       </nav>
     ));
-    route("/docs", () => <div id="page">Docs page</div>);
+    testRoute("/docs", () => <div id="page">Docs page</div>);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const docsLink = document.body.querySelector(

--- a/tests/jsdom/scaffold-slot-contract.test.tsx
+++ b/tests/jsdom/scaffold-slot-contract.test.tsx
@@ -1,7 +1,7 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, route } from "@askrjs/askr/router";
 
 import { EmptyState } from "../../src/core";
 import { Tab, Tabs } from "../../src/navs";
@@ -18,7 +18,7 @@ describe("empty state slot contract", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     window.history.replaceState({}, "", "/example");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -28,11 +28,11 @@ describe("empty state slot contract", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
   });
 
   it("should emits canonical data-slot hooks for common composition", async () => {
-    route("/example", () => (
+    testRoute("/example", () => (
       <div class="dashboard-page">
         <EmptyState
           icon={<span>!</span>}
@@ -48,7 +48,7 @@ describe("empty state slot contract", () => {
       </div>
     ));
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const emptyState = container?.querySelector('[data-slot="empty-state"]') as HTMLElement | null;

--- a/tests/jsdom/theme-contract.test.tsx
+++ b/tests/jsdom/theme-contract.test.tsx
@@ -2,7 +2,6 @@ import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../ro
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA, hydrateSPA } from "@askrjs/askr/boot";
-import {} from "@askrjs/askr/router";
 import { renderToStringSync } from "@askrjs/askr/ssr";
 
 import {

--- a/tests/jsdom/theme-contract.test.tsx
+++ b/tests/jsdom/theme-contract.test.tsx
@@ -1,7 +1,8 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA, hydrateSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, group, route } from "@askrjs/askr/router";
+import {} from "@askrjs/askr/router";
 import { renderToStringSync } from "@askrjs/askr/ssr";
 
 import {
@@ -146,7 +147,7 @@ describe("theme contracts", () => {
     clearStoredThemes();
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-theme-choice");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -156,7 +157,7 @@ describe("theme contracts", () => {
       container = undefined;
     }
 
-    clearRoutes();
+    resetTestRoutes();
     restoreLocalStorage?.();
     restoreLocalStorage = undefined;
     clearStoredThemes();
@@ -173,11 +174,12 @@ describe("theme contracts", () => {
     );
     container!.innerHTML = renderToStringSync(() => <App />);
     window.localStorage.setItem("askr-theme", "dark");
+    testRoute("/theme", App);
 
     await expect(
       hydrateSPA({
         root: container!,
-        routes: [{ path: "/theme", handler: App }],
+        registry: createTestRegistry(),
         hydrate: { verifyMarkup: true },
       }),
     ).resolves.toBeUndefined();
@@ -207,11 +209,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Theme</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Theme</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const probe = container?.querySelector('[data-slot="theme-probe"]') as HTMLElement | null;
@@ -277,11 +279,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Cat themes</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Cat themes</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const probe = container?.querySelector('[data-slot="theme-probe"]') as HTMLElement | null;
@@ -328,11 +330,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Stored theme</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Stored theme</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const probe = container?.querySelector('[data-slot="theme-probe"]') as HTMLElement | null;
@@ -390,11 +392,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Custom storage</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Custom storage</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const probe = container?.querySelector('[data-slot="theme-probe"]') as HTMLElement | null;
@@ -438,11 +440,13 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Blocked storage</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Blocked storage</div>);
     });
 
-    await expect(createSPA({ root: container!, manifest: getManifest() })).resolves.toBeUndefined();
+    await expect(
+      createSPA({ root: container!, registry: createTestRegistry() }),
+    ).resolves.toBeUndefined();
     await settle();
 
     const getProbe = () =>
@@ -477,11 +481,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Nested themes</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Nested themes</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getOuterProbe = () =>
@@ -531,11 +535,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Icon theme</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Icon theme</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const picker = container?.querySelector(
@@ -581,11 +585,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Direct theme</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Direct theme</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const click = (label: string) => {
@@ -629,11 +633,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Nested icons</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Nested icons</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const innerPicker = container?.querySelector(
@@ -669,11 +673,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: FirstApp }, () => {
-      route("/theme", () => <div id="page">First app</div>);
+    testGroup({ layout: FirstApp }, () => {
+      testRoute("/theme", () => <div id="page">First app</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const firstToggle = container?.querySelector(
@@ -686,7 +690,7 @@ describe("theme contracts", () => {
 
     cleanupApp(container!);
     container!.replaceChildren();
-    clearRoutes();
+    resetTestRoutes();
     window.history.replaceState({}, "", "/theme");
 
     const SecondApp = () => (
@@ -695,11 +699,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: SecondApp }, () => {
-      route("/theme", () => <div id="page">Second app</div>);
+    testGroup({ layout: SecondApp }, () => {
+      testRoute("/theme", () => <div id="page">Second app</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const probe = container?.querySelector('[data-slot="theme-probe"]') as HTMLElement | null;
@@ -720,11 +724,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Empty storage key</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Empty storage key</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const toggle = container?.querySelector(
@@ -756,11 +760,13 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Empty stored theme</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Empty stored theme</div>);
     });
 
-    await expect(createSPA({ root: container!, manifest: getManifest() })).resolves.toBeUndefined();
+    await expect(
+      createSPA({ root: container!, registry: createTestRegistry() }),
+    ).resolves.toBeUndefined();
     await settle();
 
     const toggle = container?.querySelector(
@@ -796,11 +802,11 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/theme", () => <div id="page">Narrow picker</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/theme", () => <div id="page">Narrow picker</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const picker = container?.querySelector(

--- a/tests/jsdom/theme-route-persistence.test.tsx
+++ b/tests/jsdom/theme-route-persistence.test.tsx
@@ -1,7 +1,8 @@
+import { createTestRegistry, resetTestRoutes, testRoute, testGroup } from "../router-test-utils";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { clearRoutes, getManifest, group, navigate, route } from "@askrjs/askr/router";
+import { navigate } from "@askrjs/askr/router";
 
 import {
   ThemePicker,
@@ -67,7 +68,7 @@ describe("theme route persistence", () => {
     document.body.appendChild(container);
     clearStoredTheme();
     window.history.replaceState({}, "", "/example");
-    clearRoutes();
+    resetTestRoutes();
   });
 
   afterEach(() => {
@@ -76,7 +77,7 @@ describe("theme route persistence", () => {
       container.remove();
       container = undefined;
     }
-    clearRoutes();
+    resetTestRoutes();
     clearStoredTheme();
     document.documentElement.removeAttribute("data-theme");
     document.documentElement.removeAttribute("data-theme-choice");
@@ -94,12 +95,12 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
-      route("/about", () => <div id="page">About</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
+      testRoute("/about", () => <div id="page">About</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
 
     expect(container.querySelector('[data-slot="theme-scope"]')).not.toBeNull();
     expect(document.documentElement.getAttribute("data-theme")).toBeNull();
@@ -152,9 +153,9 @@ describe("theme route persistence", () => {
         <main id="scope-content">Northstar</main>
       </ThemeScope>
     );
-    route("/example", App);
+    testRoute("/example", App);
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
 
     const scope = container!.querySelector('[data-slot="theme-scope"]');
     expect(container!.children).toHaveLength(1);
@@ -173,11 +174,11 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getToggle = () =>
@@ -230,11 +231,13 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await expect(createSPA({ root: container!, manifest: getManifest() })).resolves.toBeUndefined();
+    await expect(
+      createSPA({ root: container!, registry: createTestRegistry() }),
+    ).resolves.toBeUndefined();
     await settle();
 
     expect(container.querySelector('[data-slot="theme-scope"]')).not.toBeNull();
@@ -256,11 +259,11 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getToggles = () =>
@@ -319,11 +322,11 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const toggle = container?.querySelector(
@@ -359,11 +362,11 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getToggle = () =>
@@ -396,11 +399,11 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getToggle = () =>
@@ -434,11 +437,11 @@ describe("theme route persistence", () => {
       </ThemeScope>
     );
 
-    group({ layout: AppLayout }, () => {
-      route("/example", () => <div id="page">Example</div>);
+    testGroup({ layout: AppLayout }, () => {
+      testRoute("/example", () => <div id="page">Example</div>);
     });
 
-    await createSPA({ root: container!, manifest: getManifest() });
+    await createSPA({ root: container!, registry: createTestRegistry() });
     await settle();
 
     const getToggle = () =>

--- a/tests/router-test-utils.ts
+++ b/tests/router-test-utils.ts
@@ -1,0 +1,56 @@
+import {
+  createRouteRegistry,
+  group as defineGroup,
+  route as defineRoute,
+  type RouteHandler,
+  type RouteOptions,
+  type RouteRegistry,
+} from "@askrjs/askr/router";
+
+type TestRouteDefinition = {
+  path: string;
+  handler: RouteHandler;
+  options?: RouteOptions;
+  groups: Array<Parameters<typeof defineGroup>[0]>;
+};
+
+let definitions: TestRouteDefinition[] = [];
+let groupStack: Array<Parameters<typeof defineGroup>[0]> = [];
+
+export function resetTestRoutes(): void {
+  definitions = [];
+  groupStack = [];
+}
+
+export function testGroup(
+  options: Parameters<typeof defineGroup>[0],
+  definition: () => void,
+): void {
+  groupStack.push(options);
+  try {
+    definition();
+  } finally {
+    groupStack.pop();
+  }
+}
+
+export function testRoute(path: string, handler: RouteHandler, options?: RouteOptions): void {
+  definitions.push({ path, handler, options, groups: [...groupStack] });
+}
+
+export function createTestRegistry(): RouteRegistry {
+  const currentDefinitions = definitions;
+  return createRouteRegistry(() => {
+    for (const definition of currentDefinitions) {
+      const define = (groupIndex: number): void => {
+        const group = definition.groups[groupIndex];
+        if (group) {
+          defineGroup(group, () => define(groupIndex + 1));
+          return;
+        }
+        defineRoute(definition.path, definition.handler, definition.options);
+      };
+      define(0);
+    }
+  });
+}

--- a/tests/router-test-utils.ts
+++ b/tests/router-test-utils.ts
@@ -39,7 +39,7 @@ export function testRoute(path: string, handler: RouteHandler, options?: RouteOp
 }
 
 export function createTestRegistry(): RouteRegistry {
-  const currentDefinitions = definitions;
+  const currentDefinitions = [...definitions];
   return createRouteRegistry(() => {
     for (const definition of currentDefinitions) {
       const define = (groupIndex: number): void => {


### PR DESCRIPTION
## Summary\n- replace ambient route registration and cleanup in test suites with test-local explicit RouteRegistry instances\n- keep SPA, hydration, SSR, and benchmark coverage on the registry-based contract\n- add a focused test registry helper and remove legacy executable route symbols\n\n## Validation\n- npm test\n- npm run typecheck\n- npm run build\n- npm run test:publint\n- npm run pack:check