### PR TITLE
ci: install all browser engines before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@614b9e344983ad2100563c5f36f94d774d3ba6bd
+    uses: askrjs/actions/.github/workflows/publish-package.yml@3917142edc5c6534616b28094322c9107aac6f86
     with:
       install-playwright: true
     permissions:


### PR DESCRIPTION
## Summary
- pin the publish workflow to the reviewed shared-actions fix that installs Chromium, Firefox, and WebKit
- unblock the complete all-engine release gate for `@askrjs/themes@0.0.18`

## Verification
- shared action regression gate passed in askrjs/actions#6
- this PR runs the complete package CI matrix