### PR TITLE
fix: install browsers in publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@d3c866509a8245456fcd6fd929d5493737beddde
+    uses: askrjs/actions/.github/workflows/publish-package.yml@1ecd3e84c32b3ff9bb85111baabbd31f79c459dd
     with:
       install-playwright: true
     permissions:


### PR DESCRIPTION
Pins the corrected direct-publish workflow with Playwright installed in both verification and tag/publish jobs.