### PR TITLE
fix(theme): harden lifecycle and visual contracts

### DIFF
--- a/THEMING.md
+++ b/THEMING.md
@@ -755,7 +755,7 @@ These are recommended implementation defaults for component authors:
   --ak-layout-content-max-width: 75rem;
 
   /* stacking */
-  --ak-z-dropdown: 1000;
+  --ak-z-dropdown: 1500;
   --ak-z-sticky: 1100;
   --ak-z-fixed: 1200;
   --ak-z-modal-backdrop: 1300;

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -198,6 +198,20 @@ function getDefaultThemeCoordinator(): ThemeCoordinator {
   return coordinator;
 }
 
+function removeEmptyGeneratedStyleRegistries(root: Node | null): void {
+  const ownerDocument =
+    root?.nodeType === 9
+      ? (root as Document)
+      : (root?.ownerDocument ?? (typeof document === "undefined" ? null : document));
+  if (!ownerDocument) return;
+
+  for (const registry of ownerDocument.querySelectorAll<HTMLStyleElement>(
+    "style[data-askr-style-registry]",
+  )) {
+    if (!registry.textContent?.trim()) registry.remove();
+  }
+}
+
 function createThemeCoordinator() {
   const scopes = new Map<
     symbol,
@@ -239,6 +253,7 @@ function createThemeCoordinator() {
     setTimeout(() => {
       scheduled = false;
       syncActive();
+      if (scopes.size === 0) removeEmptyGeneratedStyleRegistries(root);
     }, 0);
   };
 

--- a/src/themes/default/tokens.css
+++ b/src/themes/default/tokens.css
@@ -158,7 +158,7 @@
   --ak-section-3: var(--ak-space-6);
   --ak-section-4: var(--ak-space-7);
 
-  --ak-z-dropdown: 1000;
+  --ak-z-dropdown: 1500;
   --ak-z-index-base: auto;
   --ak-z-index-sm: 10;
   --ak-z-index-md: 100;

--- a/templates/theme/tokens.css
+++ b/templates/theme/tokens.css
@@ -158,7 +158,7 @@
   --ak-section-3: var(--ak-space-6);
   --ak-section-4: var(--ak-space-7);
 
-  --ak-z-dropdown: 1000;
+  --ak-z-dropdown: 1500;
   --ak-z-index-base: auto;
   --ak-z-index-sm: 10;
   --ak-z-index-md: 100;

--- a/tests/browser/responsive-visual-contracts.test.tsx
+++ b/tests/browser/responsive-visual-contracts.test.tsx
@@ -1,0 +1,215 @@
+import { page } from "@vitest/browser/context";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { cleanupApp, createSPA } from "@askrjs/askr/boot";
+
+import { Block, Container, Grid, Section, Sidebar } from "../../src/core";
+import { Input } from "../../src/controls";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from "../../src/overlays";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeaderCell,
+  TableRow,
+} from "../../src/surfaces";
+import { createTestRegistry, resetTestRoutes, testRoute } from "../router-test-utils";
+
+import "../../src/themes/default/index.css";
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+function columnCount(value: string): number {
+  return value.split(/\s+/).filter(Boolean).length;
+}
+
+describe("responsive and visual theme contracts", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    resetTestRoutes();
+  });
+
+  afterEach(async () => {
+    cleanupApp(container);
+    container.remove();
+    resetTestRoutes();
+    await page.viewport(1280, 900);
+  });
+
+  it("should preserve layout invariants given responsive components when crossing breakpoints", async () => {
+    await page.viewport(390, 844);
+    window.history.replaceState({}, "", "/responsive-layout");
+    testRoute("/responsive-layout", () => (
+      <Container class="responsive-container" size="xl" paddingX={{ base: "sm", lg: "xl" }}>
+        <Section class="responsive-section" paddingY={{ base: "sm", lg: "xl" }}>
+          <Block class="responsive-block" direction={{ base: "column", lg: "row" }}>
+            <Grid class="responsive-grid" columns={{ base: 1, md: 2, lg: 3 }}>
+              <div>one</div>
+              <div>two</div>
+              <div>three</div>
+            </Grid>
+          </Block>
+        </Section>
+      </Container>
+    ));
+
+    await createSPA({ root: container, registry: createTestRegistry() });
+    await settle();
+
+    const block = container.querySelector<HTMLElement>(".responsive-block")!;
+    const grid = container.querySelector<HTMLElement>(".responsive-grid")!;
+    const content = container.querySelector<HTMLElement>(".responsive-container")!;
+    const section = container.querySelector<HTMLElement>(".responsive-section")!;
+    const mobilePadding = Number.parseFloat(getComputedStyle(content).paddingInlineStart);
+    const mobileSectionPadding = Number.parseFloat(getComputedStyle(section).paddingBlockStart);
+
+    expect(getComputedStyle(block).flexDirection).toBe("column");
+    expect(columnCount(getComputedStyle(grid).gridTemplateColumns)).toBe(1);
+    expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
+
+    await page.viewport(1024, 900);
+    await settle();
+
+    expect(getComputedStyle(block).flexDirection).toBe("row");
+    expect(columnCount(getComputedStyle(grid).gridTemplateColumns)).toBe(3);
+    expect(Number.parseFloat(getComputedStyle(content).paddingInlineStart)).toBeGreaterThan(
+      mobilePadding,
+    );
+    expect(Number.parseFloat(getComputedStyle(section).paddingBlockStart)).toBeGreaterThan(
+      mobileSectionPadding,
+    );
+  });
+
+  it("should keep form control states readable in the default theme", async () => {
+    window.history.replaceState({}, "", "/form-states");
+    testRoute("/form-states", () => (
+      <div data-theme="light">
+        <Input aria-label="Invalid field" aria-invalid="true" value="invalid" />
+        <Input aria-label="Disabled field" disabled value="disabled" />
+        <Input aria-label="Readonly field" readOnly value="readonly" />
+        <Input aria-label="Placeholder field" placeholder="Helpful placeholder" />
+      </div>
+    ));
+
+    await createSPA({ root: container, registry: createTestRegistry() });
+    await settle();
+
+    const invalid = container.querySelector<HTMLInputElement>('[aria-label="Invalid field"]')!;
+    const disabled = container.querySelector<HTMLInputElement>('[aria-label="Disabled field"]')!;
+    const readonly = container.querySelector<HTMLInputElement>('[aria-label="Readonly field"]')!;
+    const placeholder = container.querySelector<HTMLInputElement>(
+      '[aria-label="Placeholder field"]',
+    )!;
+    const normalBorder = getComputedStyle(readonly).borderColor;
+
+    expect(getComputedStyle(invalid).borderColor).not.toBe(normalBorder);
+    expect(getComputedStyle(disabled).opacity).toBe("0.5");
+    expect(getComputedStyle(disabled).pointerEvents).toBe("none");
+    expect(getComputedStyle(readonly).color).not.toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(readonly).opacity).toBe("1");
+    expect(getComputedStyle(placeholder, "::placeholder").color).not.toBe("rgba(0, 0, 0, 0)");
+  });
+
+  it("should preserve table readability with long content at narrow widths", async () => {
+    await page.viewport(390, 844);
+    window.history.replaceState({}, "", "/narrow-table");
+    testRoute("/narrow-table", () => (
+      <div class="table-width" style="width:320px">
+        <Table aria-label="Deployments">
+          <TableHead>
+            <TableRow>
+              <TableHeaderCell>
+                Deployment environment with a deliberately long heading
+              </TableHeaderCell>
+              <TableHeaderCell>Status</TableHeaderCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            <TableRow>
+              <TableCell>production-north-america-control-plane-blue</TableCell>
+              <TableCell>Healthy</TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </div>
+    ));
+
+    await createSPA({ root: container, registry: createTestRegistry() });
+    await settle();
+
+    const wrapper = container.querySelector<HTMLElement>(".table-width")!;
+    const table = container.querySelector<HTMLTableElement>('[data-slot="table"]')!;
+    const heading = container.querySelector<HTMLElement>('[data-slot="table-header-cell"]')!;
+    const cell = container.querySelector<HTMLElement>('[data-slot="table-cell"]')!;
+
+    expect(getComputedStyle(table).tableLayout).toBe("fixed");
+    expect(table.getBoundingClientRect().width).toBeLessThanOrEqual(
+      wrapper.getBoundingClientRect().width,
+    );
+    expect(getComputedStyle(heading).overflowWrap).toBe("anywhere");
+    expect(getComputedStyle(cell).overflowWrap).toBe("anywhere");
+  });
+
+  it("should layer and focus a dropdown opened from a dialog inside a sidebar", async () => {
+    window.history.replaceState({}, "", "/nested-overlays");
+    testRoute("/nested-overlays", () => (
+      <Sidebar aria-label="Workspace sidebar">
+        <Dialog>
+          <DialogTrigger>Open settings</DialogTrigger>
+          <DialogPortal>
+            <DialogOverlay />
+            <DialogContent>
+              <DialogTitle>Settings</DialogTitle>
+              <DialogDescription>Choose a workspace action.</DialogDescription>
+              <Dropdown id="dialog-actions">
+                <DropdownTrigger>Actions</DropdownTrigger>
+                <DropdownContent aria-label="Dialog actions">
+                  <DropdownItem>Save</DropdownItem>
+                  <DropdownItem>Archive</DropdownItem>
+                </DropdownContent>
+              </Dropdown>
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      </Sidebar>
+    ));
+
+    await createSPA({ root: container, registry: createTestRegistry() });
+    await settle();
+    container.querySelector<HTMLButtonElement>('[aria-haspopup="dialog"]')!.click();
+    await settle();
+
+    const dialog = document.body.querySelector<HTMLElement>('[data-slot="dialog-content"]')!;
+    dialog.querySelector<HTMLButtonElement>('[data-slot="dropdown-trigger"]')!.click();
+    await settle();
+
+    const menu = document.body.querySelector<HTMLElement>(
+      '[data-slot="dropdown-content"][aria-label="Dialog actions"]',
+    )!;
+    expect(menu).not.toBeNull();
+    expect(Number.parseInt(getComputedStyle(menu).zIndex, 10)).toBeGreaterThan(
+      Number.parseInt(getComputedStyle(dialog).zIndex, 10),
+    );
+    expect(menu === document.activeElement || menu.contains(document.activeElement)).toBe(true);
+  });
+});

--- a/tests/jsdom/theme-contract.test.tsx
+++ b/tests/jsdom/theme-contract.test.tsx
@@ -192,6 +192,19 @@ describe("theme contracts", () => {
 
   it("should resolve system theme after hydration and follow media changes", async () => {
     const originalMatchMedia = window.matchMedia;
+    const originalLocalStorage = window.localStorage;
+    replaceLocalStorage({
+      getItem() {
+        throw new Error("blocked read");
+      },
+      setItem() {
+        throw new Error("blocked write");
+      },
+      removeItem() {
+        throw new Error("blocked remove");
+      },
+    });
+    restoreLocalStorage = () => replaceLocalStorage(originalLocalStorage);
     let matches = true;
     const listeners = new Set<(event: MediaQueryListEvent) => void>();
     const media = {
@@ -316,6 +329,46 @@ describe("theme contracts", () => {
       cleanupApp(second);
       first.remove();
       second.remove();
+    }
+  });
+
+  it("should remove empty generated-style registries after the last themed root unmounts", async () => {
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    const styleRegistry = document.createElement("style");
+    styleRegistry.setAttribute("data-askr-style-registry", "true");
+    const populatedRegistry = document.createElement("style");
+    populatedRegistry.setAttribute("data-askr-style-registry", "true");
+    populatedRegistry.textContent = ".ak-style-retained{color:green}";
+    document.head.append(styleRegistry, populatedRegistry);
+    document.body.append(first, second);
+    const App = () => (
+      <ThemeScope defaultTheme="light" storageKey="askr-theme-registry-cleanup">
+        <ThemeProbe />
+      </ThemeScope>
+    );
+    testRoute("/theme", App);
+
+    try {
+      await createSPA({ root: first, registry: createTestRegistry() });
+      await createSPA({ root: second, registry: createTestRegistry() });
+      await settle();
+
+      cleanupApp(first);
+      await settle();
+      expect(styleRegistry.isConnected).toBe(true);
+
+      cleanupApp(second);
+      await settle();
+      expect(styleRegistry.isConnected).toBe(false);
+      expect(populatedRegistry.isConnected).toBe(true);
+    } finally {
+      cleanupApp(first);
+      cleanupApp(second);
+      first.remove();
+      second.remove();
+      styleRegistry.remove();
+      populatedRegistry.remove();
     }
   });
 

--- a/tests/unit/enhancement-contracts.test.ts
+++ b/tests/unit/enhancement-contracts.test.ts
@@ -6,13 +6,25 @@ import { CardTitle } from "../../src/components/card/card";
 import {
   serializeCssDeclarations,
   styleDeclarationsToClass,
+  styleRulesForHtml,
 } from "../../src/components/_internal/style";
+import { CAT_THEME_NAMES } from "../../src/components/theme/theme";
 import {
   DEFAULT_THEME_INDEX_FILE,
   DEFAULT_THEME_STYLES_DIR,
+  DEFAULT_THEME_TOKENS_FILE,
+  SRC_DIR,
   TEMPLATE_THEME_INDEX_FILE,
   TEMPLATE_THEME_STYLES_DIR,
+  TEMPLATE_THEME_TOKENS_FILE,
 } from "./test-paths";
+
+function tokenNames(css: string): string[] {
+  return [...css.matchAll(/(--ak-[a-z0-9-]+)\s*:/g)]
+    .map((match) => match[1]!)
+    .filter((token, index, tokens) => tokens.indexOf(token) === index)
+    .sort();
+}
 
 describe("catalog and composition contracts", () => {
   it("should render correct heading levels given card title options when semantic levels vary", () => {
@@ -52,13 +64,35 @@ describe("responsive, template, and CSS safety contracts", () => {
             : [],
       );
     expect(files(DEFAULT_THEME_STYLES_DIR).sort()).toEqual(files(TEMPLATE_THEME_STYLES_DIR).sort());
+    expect(tokenNames(readFileSync(TEMPLATE_THEME_TOKENS_FILE, "utf8"))).toEqual(
+      tokenNames(readFileSync(DEFAULT_THEME_TOKENS_FILE, "utf8")),
+    );
+
+    const presetDirectory = join(SRC_DIR, "themes", "presets");
+    const canonicalPresetTokens = tokenNames(
+      readFileSync(join(presetDirectory, `${CAT_THEME_NAMES[0]}.css`), "utf8"),
+    );
+    for (const preset of CAT_THEME_NAMES) {
+      const css = readFileSync(join(presetDirectory, `${preset}.css`), "utf8");
+      const defined = new Set(tokenNames(css));
+      expect(css, preset).toContain(`[data-theme="${preset}"]`);
+      expect(
+        canonicalPresetTokens.filter((token) => !defined.has(token)),
+        `${preset} must preserve the canonical preset token surface`,
+      ).toEqual([]);
+    }
   });
 
   it("should reject unsafe or unscoped custom-property injection given consumer style overrides when generated theme rules are serialized", () => {
     expect(styleDeclarationsToClass("--safe-token:var(--ak-color-text)")).toMatch(/^ak-style-/);
-    const generated = serializeCssDeclarations({ "--unsafe": "red; } .pwned { color: red" });
-    expect(generated).not.toContain("}");
-    expect(styleDeclarationsToClass(generated)).toBeUndefined();
+    expect(
+      serializeCssDeclarations({
+        "--safe-token": "var(--ak-color-text)",
+        "--unsafe}body": "red",
+        "--unsafe-value": "red; } .pwned { color: red",
+        background: 'url("javascript:alert(1)")',
+      }),
+    ).toBe("--safe-token:var(--ak-color-text)");
   });
 
   it("should preserve canonical token aliases given default and template entrypoints when the same component stylesheet is imported", () => {
@@ -71,5 +105,16 @@ describe("responsive, template, and CSS safety contracts", () => {
     const css = readFileSync(join(DEFAULT_THEME_STYLES_DIR, "display/card.css"), "utf8");
     expect(css).toContain(':where(.card, [data-slot="card"])');
     expect(css).not.toMatch(/(^|\n)\s*body\b/);
+
+    const className = styleDeclarationsToClass(
+      "--consumer-surface:var(--ak-color-surface);color:var(--ak-color-text)",
+    )!;
+    expect(styleRulesForHtml(`<article class="${className}"></article>`)).toEqual([
+      expect.stringMatching(
+        new RegExp(
+          `^\\.${className}\\{--consumer-surface:var\\(--ak-color-surface\\);color:var\\(--ak-color-text\\)\\}$`,
+        ),
+      ),
+    ]);
   });
 });

--- a/tests/unit/generated-style-ssr.test.ts
+++ b/tests/unit/generated-style-ssr.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createRouteRegistry, route } from "@askrjs/askr/router";
 import { createStaticGen } from "@askrjs/askr/ssg";
-import { renderToString } from "@askrjs/askr/ssr";
+import { renderRouteRequestToString, renderToString } from "@askrjs/askr/ssr";
 import { describe, expect, it } from "vite-plus/test";
 
 import { Block, Container } from "../../src/core";
@@ -85,6 +85,42 @@ describe("generated theme styles during SSR", () => {
   it("should serialize only rules used by the current server render", () => {
     const small = renderContainer("sm", NONCE);
     const large = renderContainer("xl", SECOND_NONCE);
+
+    expect(small).toContain("--ak-max-width-base:var(--ak-container-1)");
+    expect(small).not.toContain("--ak-max-width-base:var(--ak-container-4)");
+    expect(small).toContain(`nonce="${NONCE}"`);
+    expect(small).not.toContain(SECOND_NONCE);
+    expect(large).toContain("--ak-max-width-base:var(--ak-container-4)");
+    expect(large).not.toContain("--ak-max-width-base:var(--ak-container-1)");
+    expect(large).toContain(`nonce="${SECOND_NONCE}"`);
+    expect(large).not.toContain(NONCE);
+  });
+
+  it("should isolate generated style registries across concurrent SSR requests", async () => {
+    const registry = createRouteRegistry(() => {
+      route("/small", () => Container({ size: "sm", children: "small" }));
+      route("/large", () => Container({ size: "xl", children: "large" }));
+    });
+    const [smallResult, largeResult] = await Promise.all([
+      renderRouteRequestToString({ url: "/small", registry, cspNonce: NONCE }),
+      renderRouteRequestToString({ url: "/large", registry, cspNonce: SECOND_NONCE }),
+    ]);
+
+    expect(smallResult.kind).toBe("render");
+    expect(largeResult.kind).toBe("render");
+    if (smallResult.kind !== "render" || largeResult.kind !== "render") return;
+
+    const renderDocument = withThemeStyles(
+      ({ appHtml }) => `<html><head></head><body>${appHtml}</body></html>`,
+    );
+    const small = renderDocument({
+      appHtml: smallResult.html,
+      context: { cspNonce: NONCE, styles: smallResult.styles },
+    });
+    const large = renderDocument({
+      appHtml: largeResult.html,
+      context: { cspNonce: SECOND_NONCE, styles: largeResult.styles },
+    });
 
     expect(small).toContain("--ak-max-width-base:var(--ak-container-1)");
     expect(small).not.toContain("--ak-max-width-base:var(--ak-container-4)");


### PR DESCRIPTION
## Summary

- remove empty generated-style registries only after the final themed root unmounts
- keep dropdown layering above dialogs in the default and template token contracts
- backfill responsive, form, table, nested overlay, SSR concurrency, storage, sanitizer, and preset parity coverage
- document the corrected layering contract

## TDD evidence

- red: lifecycle coverage exposed retained empty registries, while nested overlay tests failed in Chromium, Firefox, and WebKit
- green: `npm run check` passed with 559 unit tests, 55 jsdom tests, 165 browser tests, lint, typecheck, build, installed-package, publint, and package checks

Closes #32
Closes #33
Closes #34