### PR TITLE
fix(themes): isolate runtime state and public contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ export const staticConfig = {
 };
 ```
 
-The wrapper also applies `context.cspNonce` to the emitted style registry.
-Use the same wrapper for an SSR `document` callback.
+The wrapper also applies `context.cspNonce` to the emitted style registry and
+requires the request-local style registrations provided by Askr 0.0.85 or
+newer. It fails clearly if generated classes and their registered rules ever
+diverge instead of emitting unstyled markup. Use the same wrapper for an SSR
+`document` callback.
 
 ## What To Import
 

--- a/THEMING.md
+++ b/THEMING.md
@@ -29,6 +29,10 @@ Token override:
 }
 ```
 
+The shipped light and dark token sets are contrast-tested. Consumer token
+overrides are ordinary CSS and cannot be validated by the runtime, so recheck
+WCAG contrast for every overridden foreground/background pair.
+
 Style override:
 
 ```css
@@ -132,6 +136,9 @@ wrapped in `data-slot="theme-toggle-content"` so icon and text compositions can
 be styled consistently across themes. If you use icon children, the direct child
 icon is sized from `var(--ak-theme-toggle-icon-size, var(--ak-icon-size, 1em))`,
 so apps can override `--ak-theme-toggle-icon-size` to fit custom icon dimensions.
+`ThemeName` accepts application-defined strings intentionally. Register custom
+names in the scope's theme options and provide a matching `[data-theme="..."]`
+token block; misspelled names otherwise remain valid custom identifiers.
 The common wrapper components also emit familiar alias classes such as
 `alert`, `btn-group`, `btn-close`, `input-group`, `tabs`, and `pills` so
 app-level CSS can stay close to familiar HTML authoring without

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.19",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@askrjs/askr": ">=0.0.64 <0.1.0",
-        "@askrjs/ui": ">=0.0.13 <0.1.0",
+        "@askrjs/askr": ">=0.0.85 <0.1.0",
+        "@askrjs/ui": ">=0.0.24 <0.1.0",
         "@askrjs/vite": ">=0.0.5 <0.1.0",
         "@tsdown/css": "0.22.8",
         "@types/node": "^26.0.0",
@@ -23,11 +23,11 @@
         "vite-plus": "^0.2.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24.15.0"
       },
       "peerDependencies": {
-        "@askrjs/askr": ">=0.0.64 <0.1.0",
-        "@askrjs/ui": ">=0.0.13 <0.1.0"
+        "@askrjs/askr": ">=0.0.85 <0.1.0",
+        "@askrjs/ui": ">=0.0.24 <0.1.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -82,9 +82,9 @@
       "license": "MIT"
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.64.tgz",
-      "integrity": "sha512-L5uCEbtfKHj0VSa/TI2+nPWpYuOUf0ttMOvSgTiNu8DLXpP4Xd3sFniNJ0a67EfTfIOu4H7hFXzi3PzroK7Y1A==",
+      "version": "0.0.85",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.85.tgz",
+      "integrity": "sha512-bhz7ErGAArsNKvY8aw2x97rzybYHOO/VOpgv0zU/dmqFiN+kdQbELh0b4grm17H4LeVgbSfL1C4abxrQg2FXsw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -92,7 +92,7 @@
         "@askrjs/schema": ">=0.0.1 <0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=24.15.0"
       }
     },
     "node_modules/@askrjs/auth": {
@@ -152,16 +152,16 @@
       }
     },
     "node_modules/@askrjs/ui": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@askrjs/ui/-/ui-0.0.13.tgz",
-      "integrity": "sha512-77IQ2rsEK9yVrIwEVLlONfu0Jjm4QzV+OjzY4I+VldX728OwnJIwCruCgvmyGc/wWfHxdtPLyJ+hGPrWJCJuyA==",
+      "version": "0.0.24",
+      "resolved": "https://registry.npmjs.org/@askrjs/ui/-/ui-0.0.24.tgz",
+      "integrity": "sha512-szET9P5q6KiR2LxgkQlCPjScVBNPt8u2YixrHAle9dOLDs3cb0Tmke2JHYoJVrmJVTajl8Ikt0FFTvSL+4xJkw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18"
+        "node": ">=24.15.0"
       },
       "peerDependencies": {
-        "@askrjs/askr": ">=0.0.52 <0.1.0"
+        "@askrjs/askr": ">=0.0.85 <0.1.0"
       }
     },
     "node_modules/@askrjs/vite": {

--- a/package.json
+++ b/package.json
@@ -332,8 +332,8 @@
     "test:checks": "vp test run -c vitest.test.checks.config.ts"
   },
   "devDependencies": {
-    "@askrjs/askr": ">=0.0.64 <0.1.0",
-    "@askrjs/ui": ">=0.0.13 <0.1.0",
+    "@askrjs/askr": ">=0.0.85 <0.1.0",
+    "@askrjs/ui": ">=0.0.24 <0.1.0",
     "@askrjs/vite": ">=0.0.5 <0.1.0",
     "@tsdown/css": "0.22.8",
     "@types/node": "^26.0.0",
@@ -346,11 +346,11 @@
     "vite-plus": "^0.2.4"
   },
   "peerDependencies": {
-    "@askrjs/askr": ">=0.0.64 <0.1.0",
-    "@askrjs/ui": ">=0.0.13 <0.1.0"
+    "@askrjs/askr": ">=0.0.85 <0.1.0",
+    "@askrjs/ui": ">=0.0.24 <0.1.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=24.15.0"
   },
   "packageManager": "npm@11.17.0"
 }

--- a/src/components/_internal/block-layout.ts
+++ b/src/components/_internal/block-layout.ts
@@ -200,7 +200,7 @@ function resolveTokenValue(
   return tokens[trimmed] ?? trimmed;
 }
 
-function resolveSpaceValue(value: string | number): string | number {
+export function resolveSpaceValue(value: string | number): string | number {
   return resolveTokenValue(value, SPACE_TOKEN_MAP);
 }
 
@@ -243,7 +243,7 @@ function resolveShadowValue(value: BlockShadow): string | undefined {
   return String(resolveTokenValue(value, SHADOW_TOKEN_MAP));
 }
 
-function setResponsiveVar<T>(
+export function setResponsiveVar<T>(
   styles: Record<string, string | number>,
   property: string,
   value: ResponsiveValue<T> | undefined,

--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -176,7 +176,7 @@ export function mergeCssVar(style: unknown, name: string, value: string): string
 const STYLE_REGISTRY_ATTR = "data-askr-style-registry";
 const STYLE_CLASS_PREFIX = "ak-style-";
 const MAX_STYLE_RULES = 512;
-const MAX_SSR_STYLE_CACHE = 4096;
+const MAX_COLLISION_CACHE = 4096;
 
 type StyleRule = {
   className: string;
@@ -184,7 +184,7 @@ type StyleRule = {
   rule: string;
 };
 
-const styleRulesByClass = new Map<string, StyleRule>();
+const styleCollisionCache = new Map<string, StyleRule>();
 type StyleRegistry = {
   element: HTMLStyleElement;
   ruleCount: number;
@@ -221,7 +221,7 @@ function escapeStyleRawText(value: string): string {
 
 function styleRuleFor(declarations: string): StyleRule {
   const className = styleClassName(declarations);
-  const existing = styleRulesByClass.get(className);
+  const existing = styleCollisionCache.get(className);
   if (existing) {
     if (existing.declarations !== declarations) {
       throw new RangeError("Theme style class collision detected.");
@@ -238,12 +238,12 @@ function styleRuleFor(declarations: string): StyleRule {
 }
 
 function rememberStyleRule(entry: StyleRule): void {
-  styleRulesByClass.delete(entry.className);
-  styleRulesByClass.set(entry.className, entry);
-  while (styleRulesByClass.size > MAX_SSR_STYLE_CACHE) {
-    const oldest = styleRulesByClass.keys().next().value;
+  styleCollisionCache.delete(entry.className);
+  styleCollisionCache.set(entry.className, entry);
+  while (styleCollisionCache.size > MAX_COLLISION_CACHE) {
+    const oldest = styleCollisionCache.keys().next().value;
     if (oldest === undefined) break;
-    styleRulesByClass.delete(oldest);
+    styleCollisionCache.delete(oldest);
   }
 }
 
@@ -326,22 +326,4 @@ export function styleDeclarationsToClass(declarations: string | undefined): stri
   registerSSRStyle(entry);
 
   return entry.className;
-}
-
-export function styleRulesForHtml(html: string): string[] {
-  const rules = new Map<string, string>();
-  const classAttributePattern = /\sclass=(?:"([^"]*)"|'([^']*)')/g;
-
-  for (const attribute of html.matchAll(classAttributePattern)) {
-    const value = attribute[1] ?? attribute[2] ?? "";
-    for (const className of value.split(/\s+/)) {
-      const entry = styleRulesByClass.get(className);
-      if (entry) rules.set(className, entry.rule);
-      if (rules.size > MAX_STYLE_RULES) {
-        throw new RangeError("Theme style registry capacity exceeded.");
-      }
-    }
-  }
-
-  return Array.from(rules.values());
 }

--- a/src/components/grid/grid.tsx
+++ b/src/components/grid/grid.tsx
@@ -1,46 +1,13 @@
 import type { JSX } from "@askrjs/askr/jsx-runtime";
 import { classes } from "../_internal/classes";
-import { mergeLayoutStyles } from "../_internal/block-layout";
+import { mergeLayoutStyles, resolveSpaceValue, setResponsiveVar } from "../_internal/block-layout";
 import { mergeProps } from "../_internal/merge-props";
 import { intrinsicElement } from "../_internal/jsx";
 import { styleDeclarationsToClass } from "../_internal/style";
-import type { BlockSpace, LayoutBreakpoint, ResponsiveValue } from "../_internal/block-layout";
+import type { BlockSpace } from "../_internal/block-layout";
 import type { GridAlign, GridColumns, GridElement, GridProps } from "./grid.types";
 
 const DEFAULT_ELEMENT = "div";
-const BREAKPOINTS: readonly LayoutBreakpoint[] = ["base", "sm", "md", "lg", "xl"];
-
-const SPACE_TOKEN_MAP: Record<BlockSpace, string> = {
-  "0": "0",
-  xs: "var(--ak-space-xs)",
-  sm: "var(--ak-space-sm)",
-  md: "var(--ak-space-md)",
-  lg: "var(--ak-space-lg)",
-  xl: "var(--ak-space-xl)",
-  "2xl": "var(--ak-space-2xl)",
-  "3xl": "var(--ak-space-3xl)",
-  page: "var(--ak-layout-page-gutter)",
-};
-
-function isResponsiveValue<T>(
-  value: ResponsiveValue<T> | undefined,
-): value is Partial<Record<LayoutBreakpoint, T>> {
-  return Boolean(
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    BREAKPOINTS.some((breakpoint) => breakpoint in value),
-  );
-}
-
-function normalizeResponsiveValue<T>(
-  value: ResponsiveValue<T> | undefined,
-): Partial<Record<LayoutBreakpoint, T>> | undefined {
-  if (value === undefined) return undefined;
-  if (isResponsiveValue(value)) return value;
-  return { base: value };
-}
-
 function resolveColumns(value: GridColumns): string {
   if (typeof value === "number") {
     return `repeat(${value}, minmax(0, 1fr))`;
@@ -51,31 +18,13 @@ function resolveColumns(value: GridColumns): string {
 }
 
 function resolveGap(value: BlockSpace): string {
-  return SPACE_TOKEN_MAP[value] ?? value;
+  return String(resolveSpaceValue(value));
 }
 
 function resolveAlign(value: GridAlign): string {
   if (value === "start") return "start";
   if (value === "end") return "end";
   return value;
-}
-
-function setResponsiveVar<T>(
-  styles: Record<string, string | number>,
-  property: string,
-  value: ResponsiveValue<T> | undefined,
-  resolve: (value: T) => string | number | undefined,
-) {
-  const normalized = normalizeResponsiveValue(value);
-  if (!normalized) return;
-
-  for (const breakpoint of BREAKPOINTS) {
-    const breakpointValue = normalized[breakpoint];
-    if (breakpointValue === undefined) continue;
-    const resolved = resolve(breakpointValue);
-    if (resolved === undefined || resolved === "") continue;
-    styles[`--ak-grid-${property}-${breakpoint}`] = resolved;
-  }
 }
 
 export function Grid<TElement extends GridElement = "div">(
@@ -99,9 +48,9 @@ export function Grid<TElement extends GridElement = "div">(
   };
 
   const styles: Record<string, string | number> = {};
-  setResponsiveVar(styles, "columns", columns, resolveColumns);
-  setResponsiveVar(styles, "gap", gap, resolveGap);
-  setResponsiveVar(styles, "align", align, resolveAlign);
+  setResponsiveVar(styles, "grid-columns", columns, resolveColumns);
+  setResponsiveVar(styles, "grid-gap", gap, resolveGap);
+  setResponsiveVar(styles, "grid-align", align, resolveAlign);
 
   const generatedClass = styleDeclarationsToClass(mergeLayoutStyles(styles, userStyle));
   const finalProps = mergeProps(rest, {

--- a/src/components/jsx-types.ts
+++ b/src/components/jsx-types.ts
@@ -5,11 +5,6 @@ declare global {
     interface Element extends JSXElement {
       readonly __askrThemesJsxElementBrand?: never;
     }
-
-    interface IntrinsicElements {
-      // @ts-ignore The Askr source types already provide a compatible fallback index.
-      [element: string]: Record<string, unknown>;
-    }
   }
 }
 

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "@askrjs/askr/jsx-runtime";
 import { defineScope, getSignal, readScope, state } from "@askrjs/askr";
-import type { JSXElement } from "@askrjs/askr/foundations/structures";
+import { cloneElement, isElement, type JSXElement } from "@askrjs/askr/foundations/structures";
 import { Button } from "@askrjs/ui";
 import type { ButtonNativeProps, PressEvent } from "@askrjs/ui";
 
@@ -67,7 +67,6 @@ export const CAT_THEME_OPTIONS: readonly ThemeOption[] = [
 
 const DEFAULT_STORAGE_KEY = "askr-theme";
 const STATIC_CHILDREN = Symbol.for("askr.static-children");
-const STATIC_CHILD_SLOTS_CACHE = Symbol.for("__askrStaticChildSlots");
 const documentThemeCoordinators = new WeakMap<Document, ThemeCoordinator>();
 type ThemeCoordinator = ReturnType<typeof createThemeCoordinator>;
 type InternalThemeScopeValue = ThemeScopeValue & {
@@ -477,16 +476,6 @@ function renderThemeToggleIconSlots(
   ));
 }
 
-function isJSXElement(value: unknown): value is JSXElement {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "$$typeof" in value &&
-    "type" in value &&
-    "props" in value
-  );
-}
-
 function cloneThemeToggleIcon(icon: unknown, key?: string): unknown {
   if (Array.isArray(icon)) {
     const clonedChildren = icon.map((child) => cloneThemeToggleIcon(child));
@@ -499,7 +488,7 @@ function cloneThemeToggleIcon(icon: unknown, key?: string): unknown {
     return clonedChildren;
   }
 
-  if (!isJSXElement(icon)) return icon;
+  if (!isElement(icon)) return icon;
 
   const props = icon.props as Record<string, unknown> | undefined;
   const clonedProps = props ? { ...props } : {};
@@ -508,15 +497,11 @@ function cloneThemeToggleIcon(icon: unknown, key?: string): unknown {
     clonedProps.children = cloneThemeToggleIcon(clonedProps.children);
   }
 
-  const iconKey = (icon.key ?? key ?? null) as string | number | null;
-  const clonedIcon = {
-    ...icon,
-    key: iconKey,
-    props: clonedProps,
-  };
-
-  delete (clonedIcon as Record<symbol, unknown>)[STATIC_CHILD_SLOTS_CACHE];
-  return clonedIcon;
+  const clonedIcon = cloneElement(icon, clonedProps);
+  return {
+    ...clonedIcon,
+    key: icon.key ?? key ?? null,
+  } satisfies JSXElement;
 }
 
 function syncThemeTarget(

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -1,6 +1,7 @@
-import { styleRulesForHtml } from "./components/_internal/style";
-
 const STYLE_REGISTRY_ATTR = "data-askr-style-registry";
+const STYLE_CLASS_PREFIX = "ak-style-";
+const CLASS_ATTRIBUTE_PATTERN = /\sclass=(?:"([^"]*)"|'([^']*)')/g;
+const MAX_STYLE_RULES = 512;
 
 type DocumentRenderArgsLike = {
   appHtml: string;
@@ -20,6 +21,16 @@ function escapeHtmlAttribute(value: string): string {
 
 function escapeStyleRawText(value: string): string {
   return value.replace(/<\/style/gi, "<\\/style");
+}
+
+function generatedStyleClasses(html: string): Set<string> {
+  const classes = new Set<string>();
+  for (const attribute of html.matchAll(CLASS_ATTRIBUTE_PATTERN)) {
+    for (const className of (attribute[1] ?? attribute[2] ?? "").split(/\s+/)) {
+      if (className.startsWith(STYLE_CLASS_PREFIX)) classes.add(className);
+    }
+  }
+  return classes;
 }
 
 function findHeadEnd(html: string): number {
@@ -72,24 +83,38 @@ export function withThemeStyles<TArgs extends DocumentRenderArgsLike>(
   return (args) => {
     const documentHtml = documentRenderer(args);
     const registeredStyles = args.context.styles;
-    const rules = registeredStyles
-      ? (() => {
-          const styles = new Map<string, string>();
-          for (const style of registeredStyles) {
-            if (!style.id || !style.cssText) {
-              throw new TypeError("Invalid SSR theme style registration.");
-            }
-            const existing = styles.get(style.id);
-            if (existing !== undefined && existing !== style.cssText) {
-              throw new RangeError(
-                `SSR style registration collision for ${JSON.stringify(style.id)}.`,
-              );
-            }
-            styles.set(style.id, style.cssText);
-          }
-          return Array.from(styles.values());
-        })()
-      : styleRulesForHtml(args.appHtml);
+    const generatedClasses = generatedStyleClasses(args.appHtml);
+    if (registeredStyles === undefined) {
+      if (generatedClasses.size > 0) {
+        throw new Error(
+          "Generated theme classes require request-local SSR style registrations from @askrjs/askr.",
+        );
+      }
+      return documentHtml;
+    }
+
+    const styles = new Map<string, string>();
+    for (const style of registeredStyles) {
+      if (!style.id || !style.cssText) {
+        throw new TypeError("Invalid SSR theme style registration.");
+      }
+      const existing = styles.get(style.id);
+      if (existing !== undefined && existing !== style.cssText) {
+        throw new RangeError(`SSR style registration collision for ${JSON.stringify(style.id)}.`);
+      }
+      styles.set(style.id, style.cssText);
+      if (styles.size > MAX_STYLE_RULES) {
+        throw new RangeError("Theme style registry capacity exceeded.");
+      }
+    }
+    for (const className of generatedClasses) {
+      if (!styles.has(className)) {
+        throw new Error(
+          `Missing request-local SSR style registration for ${JSON.stringify(className)}.`,
+        );
+      }
+    }
+    const rules = Array.from(styles.values());
     if (rules.length === 0) return documentHtml;
 
     const nonce =

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -83,7 +83,7 @@ export function withThemeStyles<TArgs extends DocumentRenderArgsLike>(
   return (args) => {
     const documentHtml = documentRenderer(args);
     const registeredStyles = args.context.styles;
-    const generatedClasses = generatedStyleClasses(args.appHtml);
+    const generatedClasses = generatedStyleClasses(documentHtml);
     if (registeredStyles === undefined) {
       if (generatedClasses.size > 0) {
         throw new Error(

--- a/tests/installed-types.js
+++ b/tests/installed-types.js
@@ -7,18 +7,18 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const consumerRoot = mkdtempSync(join(tmpdir(), "askr-themes-consumer-"));
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
-const sourcePackage = JSON.parse(readFileSync(join(repositoryRoot, "package.json"), "utf8"));
-const sourceLock = JSON.parse(readFileSync(join(repositoryRoot, "package-lock.json"), "utf8"));
-
-function lockedVersion(packageName) {
-  const version = sourceLock.packages?.[`node_modules/${packageName}`]?.version;
-  if (typeof version !== "string") {
-    throw new Error(`Missing installed version for ${packageName} in package-lock.json.`);
-  }
-  return version;
-}
 
 try {
+  const sourcePackage = JSON.parse(readFileSync(join(repositoryRoot, "package.json"), "utf8"));
+  const sourceLock = JSON.parse(readFileSync(join(repositoryRoot, "package-lock.json"), "utf8"));
+  const lockedVersion = (packageName) => {
+    const version = sourceLock.packages?.[`node_modules/${packageName}`]?.version;
+    if (typeof version !== "string") {
+      throw new Error(`Missing installed version for ${packageName} in package-lock.json.`);
+    }
+    return version;
+  };
+
   const packResult = JSON.parse(
     execFileSync(npm, ["pack", "--ignore-scripts", "--json", "--pack-destination", consumerRoot], {
       cwd: repositoryRoot,

--- a/tests/installed-types.js
+++ b/tests/installed-types.js
@@ -7,6 +7,16 @@ import { fileURLToPath } from "node:url";
 const repositoryRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const consumerRoot = mkdtempSync(join(tmpdir(), "askr-themes-consumer-"));
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const sourcePackage = JSON.parse(readFileSync(join(repositoryRoot, "package.json"), "utf8"));
+const sourceLock = JSON.parse(readFileSync(join(repositoryRoot, "package-lock.json"), "utf8"));
+
+function lockedVersion(packageName) {
+  const version = sourceLock.packages?.[`node_modules/${packageName}`]?.version;
+  if (typeof version !== "string") {
+    throw new Error(`Missing installed version for ${packageName} in package-lock.json.`);
+  }
+  return version;
+}
 
 try {
   const packResult = JSON.parse(
@@ -25,8 +35,8 @@ try {
       private: true,
       type: "module",
       dependencies: {
-        "@askrjs/askr": "0.0.64",
-        "@askrjs/ui": "0.0.13",
+        "@askrjs/askr": lockedVersion("@askrjs/askr"),
+        "@askrjs/ui": lockedVersion("@askrjs/ui"),
       },
     }),
   );
@@ -94,7 +104,6 @@ try {
   const installedPackage = JSON.parse(
     readFileSync(join(consumerRoot, "node_modules/@askrjs/themes/package.json"), "utf8"),
   );
-  const sourcePackage = JSON.parse(readFileSync(join(repositoryRoot, "package.json"), "utf8"));
   if (installedPackage.version !== sourcePackage.version) {
     throw new Error(`Installed unexpected themes version ${installedPackage.version}.`);
   }

--- a/tests/jsdom/theme-contract.test.tsx
+++ b/tests/jsdom/theme-contract.test.tsx
@@ -717,6 +717,7 @@ describe("theme contracts", () => {
     expect(window.localStorage.getItem("askr-theme-nested")).toBeNull();
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
     expect(document.documentElement.getAttribute("data-theme-choice")).toBe("dark");
+    expect(innerPicker?.isConnected).toBe(true);
 
     changePicker(innerPicker, "calico");
     await settle();

--- a/tests/unit/enhancement-contracts.test.ts
+++ b/tests/unit/enhancement-contracts.test.ts
@@ -6,7 +6,6 @@ import { CardTitle } from "../../src/components/card/card";
 import {
   serializeCssDeclarations,
   styleDeclarationsToClass,
-  styleRulesForHtml,
 } from "../../src/components/_internal/style";
 import { CAT_THEME_NAMES } from "../../src/components/theme/theme";
 import {
@@ -106,15 +105,10 @@ describe("responsive, template, and CSS safety contracts", () => {
     expect(css).toContain(':where(.card, [data-slot="card"])');
     expect(css).not.toMatch(/(^|\n)\s*body\b/);
 
-    const className = styleDeclarationsToClass(
-      "--consumer-surface:var(--ak-color-surface);color:var(--ak-color-text)",
-    )!;
-    expect(styleRulesForHtml(`<article class="${className}"></article>`)).toEqual([
-      expect.stringMatching(
-        new RegExp(
-          `^\\.${className}\\{--consumer-surface:var\\(--ak-color-surface\\);color:var\\(--ak-color-text\\)\\}$`,
-        ),
+    expect(
+      styleDeclarationsToClass(
+        "--consumer-surface:var(--ak-color-surface);color:var(--ak-color-text)",
       ),
-    ]);
+    ).toMatch(/^ak-style-/);
   });
 });

--- a/tests/unit/generated-style-ssr.test.ts
+++ b/tests/unit/generated-style-ssr.test.ts
@@ -35,6 +35,25 @@ function renderContainer(size: "sm" | "xl" = "xl", cspNonce = NONCE): string {
 }
 
 describe("generated theme styles during SSR", () => {
+  it("should reject generated classes without request-local style registrations", () => {
+    const renderDocument = withThemeStyles(
+      ({ appHtml }) => `<html><head></head><body>${appHtml}</body></html>`,
+    );
+
+    expect(() =>
+      renderDocument({
+        appHtml: '<div class="ak-style-missing">content</div>',
+        context: {},
+      }),
+    ).toThrow(/request-local.*style registrations/i);
+    expect(() =>
+      renderDocument({
+        appHtml: '<div class="ak-style-missing">content</div>',
+        context: { styles: [] },
+      }),
+    ).toThrow(/missing request-local.*ak-style-missing/i);
+  });
+
   it("should use request-local style registrations when the renderer provides them", () => {
     const html = withThemeStyles(
       ({ appHtml }) => `<html><head></head><body>${appHtml}</body></html>`,

--- a/tests/unit/generated-style-ssr.test.ts
+++ b/tests/unit/generated-style-ssr.test.ts
@@ -54,6 +54,20 @@ describe("generated theme styles during SSR", () => {
     ).toThrow(/missing request-local.*ak-style-missing/i);
   });
 
+  it("should validate generated classes added by the document renderer", () => {
+    const renderDocument = withThemeStyles(
+      ({ appHtml }) =>
+        `<html><head></head><body><main class="ak-style-wrapper">${appHtml}</main></body></html>`,
+    );
+
+    expect(() =>
+      renderDocument({
+        appHtml: "content",
+        context: { styles: [] },
+      }),
+    ).toThrow(/missing request-local.*ak-style-wrapper/i);
+  });
+
   it("should use request-local style registrations when the renderer provides them", () => {
     const html = withThemeStyles(
       ({ appHtml }) => `<html><head></head><body>${appHtml}</body></html>`,

--- a/tests/unit/theme-toggle.test.ts
+++ b/tests/unit/theme-toggle.test.ts
@@ -1,8 +1,18 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vite-plus/test";
 
 import { resolveThemeToggleIcon } from "../../src/components/theme/theme";
 
 describe("ThemeToggle", () => {
+  it("should not couple icon cloning to private renderer cache fields", () => {
+    const source = readFileSync(
+      new URL("../../src/components/theme/theme.tsx", import.meta.url),
+      "utf8",
+    );
+
+    expect(source).not.toContain("__askrStaticChildSlots");
+  });
+
   it("should falls back to the next theme icon when the current choice is system", () => {
     expect(
       resolveThemeToggleIcon("system", "light", {


### PR DESCRIPTION
## Summary
- make generated SSR styles request-local, detect missing/colliding registrations, and cap each request independently
- remove the global HTML-to-style lookup path so cache eviction cannot silently emit unstyled markup across concurrent renders
- deduplicate Grid responsive layout serialization through the shared block-layout helpers
- clone ThemeToggle icons through Askr's public `isElement`/`cloneElement` API instead of private renderer cache fields
- align the core/UI peer and Node contracts with released `askr@0.0.85` and `ui@0.0.24`
- remove the broad JSX intrinsic fallback that conflicts with core's precise public intrinsic types
- document request-local SSR requirements, custom theme-name intent, and consumer contrast responsibility

## Red-first evidence
- the packed final-artifact consumer failed with TS2411 for core intrinsic props because themes emitted a broad string index; removing that fallback makes the exact registry pair typecheck
- missing or mismatched request-local SSR registrations now fail explicitly instead of relying on a process-global, capacity-evicted rule cache
- concurrent small/large SSR and SSG fixtures prove each document receives only its own rules and nonce
- the ThemeToggle contract test proves the package no longer references `__askrStaticChildSlots`

## Verification
- clean registry install of `@askrjs/askr@0.0.85` and `@askrjs/ui@0.0.24`
- `npm audit` — 0 vulnerabilities
- `npm run fmt -- --check`
- `npm run check`
  - 561 unit tests, 2 checks, 55 jsdom tests, and 165 browser tests
  - installed tarball types/runtime, publint, and package artifact checks
- `npm run bench` — all four benchmark tiers passed, including Chromium memory soak
