### PR TITLE
chore(release): prepare @askrjs/themes 0.0.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.85 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",


### PR DESCRIPTION
## Summary
- bump `@askrjs/themes` from `0.0.19` to `0.0.20`
- release the request-local SSR style integrity and public-runtime contract cleanup from #40
- align the published themes package with `@askrjs/askr@0.0.85` and `@askrjs/ui@0.0.24`

## Verification
- `npm ci`
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm run fmt -- --check`
- `npm run check` — 562 unit, 2 checks, 55 jsdom, 165 browser, build, installed tarball, publint, artifact check

Release only; publishing remains gated on this exact head becoming clean and green.