### PR TITLE
fix: make theme components incrementally consumable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ curated preset family:
 @import "@askrjs/themes/presets";
 ```
 
+For a small page that only uses individual controls, import their JavaScript
+and CSS independently instead of the full default theme:
+
+```tsx
+import { Input } from "@askrjs/themes/input";
+import { Label } from "@askrjs/themes/label";
+import "@askrjs/themes/default/foundations.css";
+import "@askrjs/themes/default/input.css";
+import "@askrjs/themes/default/label.css";
+```
+
+The foundations entry contains tokens and base/reset styles. Component CSS
+entries contain only that component's styles. `@askrjs/themes/default` remains
+the batteries-included theme.
+
 Then set `data-theme` to `tabby`, `ginger`, `tuxedo`, `calico`, or `torty`.
 For picker/toggle composition, import `CAT_THEME_OPTIONS` and `CAT_THEME_NAMES`
 from `@askrjs/themes/theme`.

--- a/THEMING.md
+++ b/THEMING.md
@@ -123,7 +123,7 @@ Package boundaries:
   presets, and default styling.
 
 Use `@askrjs/themes/components` for the aggregate styled catalog, or the
-component subpaths such as `@askrjs/themes/button`,
+tree-shakeable component subpaths such as `@askrjs/themes/button`,
 `@askrjs/themes/card`, and `@askrjs/themes/dialog`. The aggregate catalog
 contains styled components such as Button, ButtonGroup, Close, InputGroup,
 Block, Container, Header, Main, Sidebar, Navbar, NavBrand, NavDropdown, Alert,

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -140,9 +140,13 @@ default theme also provides a small set of class aliases for raw HTML.
 See [Architecture](./architecture.md) for the package boundary between
 `@askrjs/askr`, `@askrjs/ui`, and `@askrjs/themes`.
 The public package surface is organized as a component catalog:
-`@askrjs/themes/components` exports the aggregate catalog, and component
-subpaths such as `@askrjs/themes/button`, `@askrjs/themes/card`, and
-`@askrjs/themes/dialog` point at the same styled catalog build. `@askrjs/ui`
+`@askrjs/themes/components` exports the batteries-included aggregate catalog,
+while component subpaths such as `@askrjs/themes/button`,
+`@askrjs/themes/card`, and `@askrjs/themes/dialog` resolve to independent,
+tree-shakeable JavaScript entries without importing theme CSS. Pair those with
+`@askrjs/themes/default/foundations.css` and only the component styles needed
+by the page. All individual styles are available below
+`@askrjs/themes/default/styles/*`. `@askrjs/ui`
 owns advanced behavior details; `@askrjs/themes` owns the visual shell around
 those primitives. `Dialog` is the canonical modal surface name; `Drawer` and
 `Sheet` are dialog-backed catalog names for shadcn parity. Chart components stay

--- a/package.json
+++ b/package.json
@@ -58,245 +58,29 @@
       "types": "./dist/ssr.d.ts",
       "import": "./dist/ssr.js"
     },
-    "./accordion": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./alert": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./alert-dialog": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./aspect-ratio": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./avatar": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./badge": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./breadcrumb": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./button": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./button-group": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./calendar": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./card": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./carousel": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./checkbox": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./collapsible": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./combobox": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./command": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./context-menu": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./data-table": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./date-picker": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./dialog": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./direction": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./drawer": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./dropdown-menu": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./empty": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./field": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./form": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./hover-card": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./input": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./input-group": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./input-otp": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./item": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./kbd": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./label": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./menubar": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./native-select": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./navigation-menu": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./pagination": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./popover": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./progress": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./radio-group": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./resizable": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./scroll-area": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./select": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./separator": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./sheet": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./sidebar": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./skeleton": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./slider": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./sonner": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./spinner": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./switch": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./table": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./tabs": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./textarea": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./toast": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./toggle": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./toggle-group": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./tooltip": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
-    },
-    "./typography": {
-      "types": "./dist/components.d.ts",
-      "import": "./dist/components.js"
+    "./*": {
+      "types": "./dist/entries/*.d.ts",
+      "import": "./dist/entries/*.js"
     },
     "./default/tokens.css": {
       "types": "./src/css.d.ts",
       "default": "./src/themes/default/tokens.css"
+    },
+    "./default/foundations.css": {
+      "types": "./src/css.d.ts",
+      "default": "./src/themes/default/foundations.css"
+    },
+    "./default/input.css": {
+      "types": "./src/css.d.ts",
+      "default": "./src/themes/default/styles/forms/input.css"
+    },
+    "./default/label.css": {
+      "types": "./src/css.d.ts",
+      "default": "./src/themes/default/styles/forms/label.css"
+    },
+    "./default/styles/*": {
+      "types": "./src/css.d.ts",
+      "default": "./src/themes/default/styles/*"
     },
     "./templates/*": {
       "types": "./src/css.d.ts",
@@ -326,7 +110,8 @@
     "typecheck": "tsc -p tsconfig.pack.json --noEmit",
     "build": "vp pack",
     "pack:check": "node tests/package-artifacts.js",
-    "check": "npm run lint && npm run typecheck && npm test && npm run build && npm run test:installed && npm run test:publint && npm run pack:check",
+    "test:bundle": "node tests/granular-bundle.js",
+    "check": "npm run lint && npm run typecheck && npm test && npm run build && npm run test:installed && npm run test:publint && npm run pack:check && npm run test:bundle",
     "prepack": "npm run build",
     "prepublishOnly": "npm run check",
     "test:checks": "vp test run -c vitest.test.checks.config.ts"

--- a/src/entries/accordion.ts
+++ b/src/entries/accordion.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/accordion";

--- a/src/entries/alert-dialog.ts
+++ b/src/entries/alert-dialog.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/alert-dialog";

--- a/src/entries/alert.ts
+++ b/src/entries/alert.ts
@@ -1,0 +1,1 @@
+export * from "../components/alert";

--- a/src/entries/aspect-ratio.ts
+++ b/src/entries/aspect-ratio.ts
@@ -1,0 +1,1 @@
+export * from "../components/aspect-ratio";

--- a/src/entries/avatar.ts
+++ b/src/entries/avatar.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/avatar";

--- a/src/entries/badge.ts
+++ b/src/entries/badge.ts
@@ -1,0 +1,1 @@
+export * from "../components/badge";

--- a/src/entries/breadcrumb.ts
+++ b/src/entries/breadcrumb.ts
@@ -1,0 +1,9 @@
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+} from "../components/catalog";

--- a/src/entries/button-group.ts
+++ b/src/entries/button-group.ts
@@ -1,0 +1,1 @@
+export * from "../components/button-group";

--- a/src/entries/button.ts
+++ b/src/entries/button.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/button";

--- a/src/entries/calendar.ts
+++ b/src/entries/calendar.ts
@@ -1,0 +1,14 @@
+export {
+  Calendar,
+  CalendarHeader,
+  CalendarCaption,
+  CalendarNav,
+  CalendarPreviousButton,
+  CalendarNextButton,
+  CalendarGrid,
+  CalendarHead,
+  CalendarBody,
+  CalendarRow,
+  CalendarCell,
+  CalendarDay,
+} from "../components/catalog";

--- a/src/entries/card.ts
+++ b/src/entries/card.ts
@@ -1,0 +1,1 @@
+export * from "../components/card";

--- a/src/entries/carousel.ts
+++ b/src/entries/carousel.ts
@@ -1,0 +1,7 @@
+export {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "../components/catalog";

--- a/src/entries/checkbox.ts
+++ b/src/entries/checkbox.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/checkbox";

--- a/src/entries/collapsible.ts
+++ b/src/entries/collapsible.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/collapsible";

--- a/src/entries/combobox.ts
+++ b/src/entries/combobox.ts
@@ -1,0 +1,1 @@
+export { Combobox, ComboboxInput, ComboboxList, ComboboxOption } from "../components/catalog";

--- a/src/entries/command.ts
+++ b/src/entries/command.ts
@@ -1,0 +1,13 @@
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandHeader,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandGroupHeading,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+} from "../components/catalog";

--- a/src/entries/context-menu.ts
+++ b/src/entries/context-menu.ts
@@ -1,0 +1,10 @@
+export {
+  Dropdown as ContextMenu,
+  DropdownGroup as ContextMenuGroup,
+  DropdownItem as ContextMenuItem,
+  DropdownLabel as ContextMenuLabel,
+  DropdownPortal as ContextMenuPortal,
+  DropdownSeparator as ContextMenuSeparator,
+  DropdownTrigger as ContextMenuTrigger,
+} from "@askrjs/ui/dropdown";
+export { DropdownContent as ContextMenuContent } from "../components/overlays/dropdown-content";

--- a/src/entries/data-table.ts
+++ b/src/entries/data-table.ts
@@ -1,0 +1,1 @@
+export { DataTable } from "../components/catalog";

--- a/src/entries/date-picker.ts
+++ b/src/entries/date-picker.ts
@@ -1,0 +1,1 @@
+export { DatePicker, DatePickerInput } from "../components/catalog";

--- a/src/entries/dialog.ts
+++ b/src/entries/dialog.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/dialog";

--- a/src/entries/direction.ts
+++ b/src/entries/direction.ts
@@ -1,0 +1,1 @@
+export { Direction } from "../components/catalog";

--- a/src/entries/drawer.ts
+++ b/src/entries/drawer.ts
@@ -1,0 +1,10 @@
+export {
+  Dialog as Drawer,
+  DialogClose as DrawerClose,
+  DialogContent as DrawerContent,
+  DialogDescription as DrawerDescription,
+  DialogOverlay as DrawerOverlay,
+  DialogPortal as DrawerPortal,
+  DialogTitle as DrawerTitle,
+  DialogTrigger as DrawerTrigger,
+} from "@askrjs/ui/dialog";

--- a/src/entries/dropdown-menu.ts
+++ b/src/entries/dropdown-menu.ts
@@ -1,0 +1,10 @@
+export {
+  Dropdown as DropdownMenu,
+  DropdownGroup as DropdownMenuGroup,
+  DropdownItem as DropdownMenuItem,
+  DropdownLabel as DropdownMenuLabel,
+  DropdownPortal as DropdownMenuPortal,
+  DropdownSeparator as DropdownMenuSeparator,
+  DropdownTrigger as DropdownMenuTrigger,
+} from "@askrjs/ui/dropdown";
+export { DropdownContent as DropdownMenuContent } from "../components/overlays/dropdown-content";

--- a/src/entries/empty.ts
+++ b/src/entries/empty.ts
@@ -1,0 +1,8 @@
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+} from "../components/catalog";

--- a/src/entries/field.ts
+++ b/src/entries/field.ts
@@ -1,0 +1,1 @@
+export * from "../components/field";

--- a/src/entries/form.ts
+++ b/src/entries/form.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/form";

--- a/src/entries/hover-card.ts
+++ b/src/entries/hover-card.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/hover-card";

--- a/src/entries/input-group.ts
+++ b/src/entries/input-group.ts
@@ -1,0 +1,1 @@
+export * from "../components/input-group";

--- a/src/entries/input-otp.ts
+++ b/src/entries/input-otp.ts
@@ -1,0 +1,1 @@
+export { InputOTP, InputOTPGroup, InputOTPSlot, InputOTPSeparator } from "../components/catalog";

--- a/src/entries/input.ts
+++ b/src/entries/input.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/input";

--- a/src/entries/item.ts
+++ b/src/entries/item.ts
@@ -1,0 +1,11 @@
+export {
+  Item,
+  ItemGroup,
+  ItemHeader,
+  ItemMedia,
+  ItemContent,
+  ItemTitle,
+  ItemDescription,
+  ItemActions,
+  ItemFooter,
+} from "../components/catalog";

--- a/src/entries/kbd.ts
+++ b/src/entries/kbd.ts
@@ -1,0 +1,1 @@
+export { Kbd } from "../components/catalog";

--- a/src/entries/label.ts
+++ b/src/entries/label.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/label";

--- a/src/entries/menubar.ts
+++ b/src/entries/menubar.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/menubar";

--- a/src/entries/native-select.ts
+++ b/src/entries/native-select.ts
@@ -1,0 +1,1 @@
+export { NativeSelect } from "../components/catalog";

--- a/src/entries/navigation-menu.ts
+++ b/src/entries/navigation-menu.ts
@@ -1,0 +1,10 @@
+export {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+  NavigationMenuViewport,
+  NavigationMenuIndicator,
+} from "../components/catalog";

--- a/src/entries/pagination.ts
+++ b/src/entries/pagination.ts
@@ -1,0 +1,9 @@
+export {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationPrevious,
+  PaginationNext,
+  PaginationEllipsis,
+} from "../components/catalog";

--- a/src/entries/popover.ts
+++ b/src/entries/popover.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/popover";

--- a/src/entries/progress.ts
+++ b/src/entries/progress.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/progress";

--- a/src/entries/radio-group.ts
+++ b/src/entries/radio-group.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/radio-group";

--- a/src/entries/resizable.ts
+++ b/src/entries/resizable.ts
@@ -1,0 +1,1 @@
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "../components/catalog";

--- a/src/entries/scroll-area.ts
+++ b/src/entries/scroll-area.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/scroll-area";

--- a/src/entries/select.ts
+++ b/src/entries/select.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/select";

--- a/src/entries/separator.ts
+++ b/src/entries/separator.ts
@@ -1,0 +1,1 @@
+export * from "../components/separator";

--- a/src/entries/sheet.ts
+++ b/src/entries/sheet.ts
@@ -1,0 +1,14 @@
+export {
+  Dialog as Sheet,
+  DialogClose as SheetClose,
+  DialogOverlay as SheetOverlay,
+  DialogPortal as SheetPortal,
+  DialogTrigger as SheetTrigger,
+} from "@askrjs/ui/dialog";
+export {
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "../components/catalog";

--- a/src/entries/sidebar.ts
+++ b/src/entries/sidebar.ts
@@ -1,0 +1,1 @@
+export * from "../components/sidebar";

--- a/src/entries/skeleton.ts
+++ b/src/entries/skeleton.ts
@@ -1,0 +1,1 @@
+export * from "../components/skeleton";

--- a/src/entries/slider.ts
+++ b/src/entries/slider.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/slider";

--- a/src/entries/sonner.ts
+++ b/src/entries/sonner.ts
@@ -1,0 +1,1 @@
+export { Sonner, Toaster } from "../components/catalog";

--- a/src/entries/spinner.ts
+++ b/src/entries/spinner.ts
@@ -1,0 +1,1 @@
+export * from "../components/spinner";

--- a/src/entries/switch.ts
+++ b/src/entries/switch.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/switch";

--- a/src/entries/table.ts
+++ b/src/entries/table.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/table";

--- a/src/entries/tabs.ts
+++ b/src/entries/tabs.ts
@@ -1,0 +1,2 @@
+export { Pill, Pills, Tab, Tabs } from "../components/nav";
+export { TabsContent, TabsList, TabsTrigger } from "../components/catalog";

--- a/src/entries/textarea.ts
+++ b/src/entries/textarea.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/textarea";

--- a/src/entries/toast.ts
+++ b/src/entries/toast.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/toast";

--- a/src/entries/toggle-group.ts
+++ b/src/entries/toggle-group.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/toggle-group";

--- a/src/entries/toggle.ts
+++ b/src/entries/toggle.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/toggle";

--- a/src/entries/tooltip.ts
+++ b/src/entries/tooltip.ts
@@ -1,0 +1,1 @@
+export * from "@askrjs/ui/tooltip";

--- a/src/entries/typography.ts
+++ b/src/entries/typography.ts
@@ -1,0 +1,12 @@
+export {
+  Typography,
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyH4,
+  TypographyP,
+  TypographyBlockquote,
+  TypographyList,
+  TypographyLead,
+  TypographyMuted,
+} from "../components/catalog";

--- a/src/themes/default/foundations.css
+++ b/src/themes/default/foundations.css
@@ -1,0 +1,6 @@
+@import "./tokens.css";
+@import "./styles/base/reset.css";
+@import "./styles/base/typography.css";
+@import "./styles/base/text.css";
+@import "./styles/base/icon.css";
+@import "./styles/base/utilities.css";

--- a/tests/granular-bundle.js
+++ b/tests/granular-bundle.js
@@ -1,0 +1,60 @@
+import { build } from "vite";
+
+const fixtureId = "\0granular-consumer";
+const result = await build({
+  configFile: false,
+  logLevel: "silent",
+  plugins: [
+    {
+      name: "granular-consumer",
+      resolveId(id) {
+        if (id === "granular-consumer") return fixtureId;
+      },
+      load(id) {
+        if (id !== fixtureId) return;
+        return [
+          'import { Input } from "@askrjs/themes/input";',
+          'import { Label } from "@askrjs/themes/label";',
+          'import "@askrjs/themes/default/foundations.css";',
+          'import "@askrjs/themes/default/input.css";',
+          'import "@askrjs/themes/default/label.css";',
+          "console.log(Input, Label);",
+        ].join("\n");
+      },
+    },
+  ],
+  build: {
+    write: false,
+    rollupOptions: { input: "granular-consumer" },
+  },
+});
+
+const outputs = Array.isArray(result) ? result.flatMap(({ output }) => output) : result.output;
+const javascript = outputs
+  .filter(({ type }) => type === "chunk")
+  .map(({ code }) => code)
+  .join("\n");
+const css = outputs
+  .filter(({ type, fileName }) => type === "asset" && fileName.endsWith(".css"))
+  .map(({ source }) => String(source))
+  .join("\n");
+
+for (const unrelated of ["DialogPortal", "PopoverContent", "VirtualTable", "SidebarRail"]) {
+  if (javascript.includes(unrelated)) {
+    throw new Error(`Granular JavaScript bundle includes unrelated ${unrelated}.`);
+  }
+}
+
+for (const unrelated of ["dialog-content", "popover-content", "sidebar"]) {
+  if (new RegExp(`data-slot=["']?${unrelated}["']?`, "u").test(css)) {
+    throw new Error(`Granular CSS bundle includes unrelated selector ${unrelated}.`);
+  }
+}
+
+if (!/data-slot=["']?input["']?/u.test(css) || !/data-slot=["']?label["']?/u.test(css)) {
+  throw new Error("Granular CSS bundle is missing Input or Label styles.");
+}
+
+if (Buffer.byteLength(css) >= 60_000) {
+  throw new Error(`Expected granular CSS below 60 kB, received ${Buffer.byteLength(css)} bytes.`);
+}

--- a/tests/installed-types.js
+++ b/tests/installed-types.js
@@ -52,6 +52,11 @@ try {
       'import "@askrjs/themes/default";',
       'import "@askrjs/themes/presets";',
       'import "@askrjs/themes/default/tokens.css";',
+      'import "@askrjs/themes/default/foundations.css";',
+      'import "@askrjs/themes/default/input.css";',
+      'import "@askrjs/themes/default/label.css";',
+      'import { Input, type InputProps } from "@askrjs/themes/input";',
+      'import { Label, type LabelProps } from "@askrjs/themes/label";',
       'import "@askrjs/themes/templates/theme/index.css";',
       'import { Block, type BlockProps, type DialogProps, type GridProps, type SidebarRailProps, type TextProps } from "@askrjs/themes/components";',
       'import { withThemeStyles } from "@askrjs/themes/ssr";',
@@ -60,7 +65,7 @@ try {
       "const grid: GridProps = { columns: 2 };",
       'const text: TextProps = { tone: "success" };',
       'const rail: SidebarRailProps = { type: "button" };',
-      "void fixture; void block; void grid; void text; void rail; void (null as DialogProps | null); void withThemeStyles;",
+      "void fixture; void block; void grid; void text; void rail; void (null as DialogProps | InputProps | LabelProps | null); void Input; void Label; void withThemeStyles;",
     ].join("\n"),
   );
   writeFileSync(

--- a/tests/package-artifacts.js
+++ b/tests/package-artifacts.js
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join, normalize } from "node:path";
 
 const npm = process.platform === "win32" ? "npm.cmd" : "npm";
@@ -15,7 +15,60 @@ if (result.length !== 1) {
 }
 
 const packedFiles = new Set(result[0].files.map(({ path }) => normalize(path)));
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
 const sourceMappingPattern = /[#@]\s*sourceMappingURL=([^\s*]+)/gu;
+
+const componentExport = packageJson.exports["./*"];
+if (
+  componentExport?.import !== "./dist/entries/*.js" ||
+  componentExport?.types !== "./dist/entries/*.d.ts"
+) {
+  throw new Error("Expected component subpaths to use the dedicated entry pattern.");
+}
+
+const componentEntries = readdirSync("src/entries")
+  .filter((file) => file.endsWith(".ts"))
+  .map((file) => file.slice(0, -3));
+
+for (const component of componentEntries) {
+  if (!packedFiles.has(normalize(`dist/entries/${component}.js`))) {
+    throw new Error(`Packed artifact is missing dist/entries/${component}.js.`);
+  }
+
+  const source = readFileSync(`dist/entries/${component}.js`, "utf8");
+  if (source.trim().length === 0) {
+    throw new Error(`dist/entries/${component}.js is empty.`);
+  }
+  if (source.includes("../components.js") || source.includes("themes/default")) {
+    throw new Error(`dist/entries/${component}.js depends on the aggregate component entry.`);
+  }
+}
+
+for (const component of ["input", "label"]) {
+  const source = readFileSync(`dist/entries/${component}.js`, "utf8");
+  for (const unrelated of ["Dialog", "Popover", "Sidebar", "VirtualTable"]) {
+    if (source.includes(unrelated)) {
+      throw new Error(`dist/${component}.js unexpectedly includes ${unrelated}.`);
+    }
+  }
+}
+
+for (const cssExport of ["foundations", "input", "label"]) {
+  const key = `./default/${cssExport}.css`;
+  const target = packageJson.exports[key]?.default;
+  if (typeof target !== "string" || !packedFiles.has(normalize(target.replace(/^\.\//u, "")))) {
+    throw new Error(`Expected ${key} to resolve to packed granular CSS.`);
+  }
+}
+
+if (packageJson.exports["./default/styles/*"]?.default !== "./src/themes/default/styles/*") {
+  throw new Error("Expected all individual default component styles to be publicly addressable.");
+}
+
+const inputCss = readFileSync("src/themes/default/styles/forms/input.css", "utf8");
+if (inputCss.includes('data-slot="dialog') || inputCss.includes('data-slot="sidebar')) {
+  throw new Error("Granular input CSS includes unrelated component selectors.");
+}
 
 for (const file of result[0].files) {
   if (!/\.(?:css|d\.ts|js)$/u.test(file.path)) continue;

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import * as ts from "typescript";
 import { describe, expect, it } from "vite-plus/test";
@@ -173,16 +173,39 @@ describe("package surface", () => {
       types: CSS_TYPE_TARGET,
       default: "./src/themes/default/tokens.css",
     });
+    expect(pkg.exports?.["./default/foundations.css"]).toEqual({
+      types: CSS_TYPE_TARGET,
+      default: "./src/themes/default/foundations.css",
+    });
+    expect(pkg.exports?.["./default/input.css"]).toEqual({
+      types: CSS_TYPE_TARGET,
+      default: "./src/themes/default/styles/forms/input.css",
+    });
+    expect(pkg.exports?.["./default/label.css"]).toEqual({
+      types: CSS_TYPE_TARGET,
+      default: "./src/themes/default/styles/forms/label.css",
+    });
     expect(pkg.exports?.["./templates/*"]).toEqual({
       types: CSS_TYPE_TARGET,
       default: "./templates/*",
+    });
+    expect(pkg.exports?.["./*"]).toEqual({
+      types: "./dist/entries/*.d.ts",
+      import: "./dist/entries/*.js",
     });
     expect(pkg.exports?.["./chart"]).toBeUndefined();
     expect(pkg.exports?.["./charts"]).toBeUndefined();
 
     for (const subpath of SHADCN_THEME_COMPONENT_SUBPATHS) {
-      expect(pkg.exports?.[`./${subpath}`], subpath).toEqual(COMPONENT_EXPORT_TARGET);
+      expect(pkg.exports?.[`./${subpath}`], subpath).toBeUndefined();
     }
+
+    expect(
+      readdirSync(join(ROOT_DIR, "src/entries"))
+        .filter((entry) => entry.endsWith(".ts"))
+        .map((entry) => entry.slice(0, -3))
+        .sort(),
+    ).toEqual([...SHADCN_THEME_COMPONENT_SUBPATHS].sort());
 
     for (const entrypoint of REMOVED_FAMILY_EXPORTS) {
       expect(pkg.exports?.[entrypoint], entrypoint).toBeUndefined();
@@ -244,6 +267,10 @@ describe("package surface", () => {
 
       const cssTarget = (target as { default?: string }).default;
       expect(typeof cssTarget).toBe("string");
+      if (entrypoint.includes("*") && cssTarget?.includes("*")) {
+        expect(existsSync(join(ROOT_DIR, cssTarget.slice(0, cssTarget.indexOf("*"))))).toBe(true);
+        continue;
+      }
       expect(
         existsSync(join(ROOT_DIR, cssTarget as string)),
         `${entrypoint} points at ${cssTarget}`,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,12 @@
+import { readdirSync } from "node:fs";
 import { defineConfig } from "vite-plus";
 
 const externalPackagePattern = /^@askrjs\/(?:askr|ui)(?:\/.*)?$/;
+const componentEntries = Object.fromEntries(
+  readdirSync(new URL("./src/entries", import.meta.url), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => [`entries/${entry.name.slice(0, -3)}`, `src/entries/${entry.name}`]),
+);
 
 export default defineConfig({
   esbuild: {
@@ -12,6 +18,7 @@ export default defineConfig({
       components: "src/components.ts",
       core: "src/core.ts",
       controls: "src/controls.ts",
+      ...componentEntries,
       navs: "src/navs.ts",
       overlays: "src/overlays.ts",
       ssr: "src/ssr.ts",
@@ -37,6 +44,7 @@ export default defineConfig({
         components: "src/components.ts",
         core: "src/core.ts",
         controls: "src/controls.ts",
+        ...componentEntries,
         navs: "src/navs.ts",
         overlays: "src/overlays.ts",
         ssr: "src/ssr.ts",


### PR DESCRIPTION
Closes #42

## Summary
- publish independent JavaScript entry points for every public component family
- expose foundations and granular component CSS while preserving the full default theme
- add packed-artifact, installed-consumer, catalog-parity, and Vite bundle regressions

## Verification
- `npm run check`
- 563 unit tests
- 55 jsdom tests
- 165 browser tests across Chromium, Firefox, and WebKit
- publint, packed artifact, installed consumer, and minimal Vite bundle checks