### PR TITLE
refactor: use Askr-native theme catalog naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/askrjs/askr-themes/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/askrjs/askr-themes/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/%40askrjs%2Fthemes.svg)](https://www.npmjs.com/package/@askrjs/themes)
 
-CSS tokens and a shadcn-style styled component catalog for Askr apps.
+CSS tokens and a styled component catalog for Askr apps.
 
 `@askrjs/themes` is the visual companion to `@askrjs/ui` and
 `@askrjs/charts`. It owns the default theme and styled component catalog while

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The foundations entry contains tokens and base/reset styles. Component CSS
 entries contain only that component's styles. `@askrjs/themes/default` remains
 the batteries-included theme.
 
+See [Acknowledgements](./docs/acknowledgements.md) for the open-source projects
+that inspired parts of the design philosophy.
+
 Then set `data-theme` to `tabby`, `ginger`, `tuxedo`, `calico`, or `torty`.
 For picker/toggle composition, import `CAT_THEME_OPTIONS` and `CAT_THEME_NAMES`
 from `@askrjs/themes/theme`.

--- a/THEMING.md
+++ b/THEMING.md
@@ -190,7 +190,7 @@ This contract is intentionally semantic, not component-specific.
 The token system must:
 
 - support both light and dark themes
-- theme headless UI primitives consistently
+- theme behavior-first UI primitives consistently
 - optimize for admin and internal tools by default
 - avoid hardcoded component styling
 - provide enough semantic coverage for real apps

--- a/THEMING.md
+++ b/THEMING.md
@@ -220,7 +220,7 @@ This spec does not:
 5. Theme blocks should only override theme-dependent values.
 6. Layout, spacing, typography scale, icon scale, and breakpoints belong in the global root unless intentionally themed.
 7. Default visual choices should reduce end-user design decisions: one accent, subtle borders, compact density, restrained radius, and minimal decorative styling.
-8. The default theme should stay crisp and low-noise, closer to a shadcn-style baseline than a glossy decorative system.
+8. The default theme should stay crisp and low-noise, favoring a restrained product baseline over a glossy decorative system.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Default theme tokens, styles, and visual components for Askr applications.
 - [Tokens](./tokens.md) - design token reference and overrides
 - [Theming](./theming.md) - CSS architecture, selector contracts, and visual QA
 - [Regression coverage](./regression-coverage.md) - permanent coverage matrix
+- [Acknowledgements](./acknowledgements.md) - gratitude for open-source inspiration
 
 ## Quick Start
 

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,22 @@
+# Acknowledgements
+
+Askr Themes is its own implementation and design system, but it benefits from
+the ideas shared by the wider open-source UI community. We are especially
+grateful to:
+
+- [shadcn/ui](https://ui.shadcn.com/) for demonstrating how an open component
+  catalog can combine strong defaults with application ownership and
+  customization.
+- [Radix Primitives](https://www.radix-ui.com/primitives) for advancing
+  accessible, composable UI primitives and publishing clear guidance about
+  interaction and WAI-ARIA behavior.
+
+Their work helped inform our thinking about component anatomy, restrained
+visual defaults, composition, and accessibility. Askr Themes does not ship or
+wrap those projects; its runtime, components, CSS, and tests use Askr-native
+contracts and terminology.
+
+This page recognizes creative and technical inspiration. It is not a software
+bill of materials or a substitute for license notices: dependency attribution
+and license terms remain with the corresponding distributed dependencies and
+package metadata.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ work together like this:
 - `@askrjs/askr` owns creation, rendering, routing, and runtime primitives.
 - `@askrjs/ui` owns behavior, focus management, keyboard interaction, and ARIA.
 - `@askrjs/themes` owns tokens, visual styling, layout composition, and the
-  shadcn-style styled component catalog.
+  styled component catalog.
 - `@askrjs/charts` owns chart components and chart-specific chrome.
 
 That boundary is intentional. It keeps behavior local to `@askrjs/ui` and keeps

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -149,7 +149,7 @@ by the page. All individual styles are available below
 `@askrjs/themes/default/styles/*`. `@askrjs/ui`
 owns advanced behavior details; `@askrjs/themes` owns the visual shell around
 those primitives. `Dialog` is the canonical modal surface name; `Drawer` and
-`Sheet` are dialog-backed catalog names for shadcn parity. Chart components stay
+`Sheet` are dialog-backed catalog aliases. Chart components stay
 in `@askrjs/charts`.
 `Button` comes from `@askrjs/ui`; `@askrjs/themes` re-exports and styles it,
 while wrappers like `ButtonGroup`, `Close`, `Field`, and `InputGroup` stay

--- a/src/parity.ts
+++ b/src/parity.ts
@@ -1,4 +1,4 @@
-export const SHADCN_THEME_COMPONENTS = [
+export const THEME_COMPONENTS = [
   "Accordion",
   "Alert",
   "AlertDialog",
@@ -60,9 +60,9 @@ export const SHADCN_THEME_COMPONENTS = [
   "Typography",
 ] as const;
 
-export const SHADCN_CHART_COMPONENT = "Chart" as const;
+export const EXCLUDED_CHART_COMPONENT = "Chart" as const;
 
-export const SHADCN_THEME_COMPONENT_SUBPATHS = [
+export const THEME_COMPONENT_SUBPATHS = [
   "accordion",
   "alert",
   "alert-dialog",

--- a/tests/browser/default-visual-baseline.test.tsx
+++ b/tests/browser/default-visual-baseline.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
 
-import { SHADCN_NEW_YORK_V4_COMPUTED } from "../fixtures/shadcn-new-york-v4";
+import { DEFAULT_VISUAL_BASELINE } from "../fixtures/default-visual-baseline";
 import "../../src/themes/default/index.css";
 
 function px(value: string): number {
@@ -11,13 +11,13 @@ function expectNotTransparent(value: string, label: string): void {
   expect(value, label).not.toBe("rgba(0, 0, 0, 0)");
 }
 
-describe("shadcn New York visual parity", () => {
+describe("default theme visual baseline", () => {
   afterEach(() => {
     document.documentElement.removeAttribute("data-theme");
     document.body.innerHTML = "";
   });
 
-  it("should keep shared primitive computed styles aligned with shadcn defaults", () => {
+  it("should keep shared primitive computed styles aligned with the default baseline", () => {
     document.body.innerHTML = `
       <button data-slot="button">Save</button>
       <input data-slot="input" value="workspace" />
@@ -51,27 +51,23 @@ describe("shadcn New York visual parity", () => {
     const tabsTrigger = document.querySelector('[data-slot="tabs-trigger"]') as HTMLElement;
     const tooltip = document.querySelector('[data-slot="tooltip-content"]') as HTMLElement;
 
-    expect(px(getComputedStyle(button).minHeight)).toBe(SHADCN_NEW_YORK_V4_COMPUTED.buttonHeight);
-    expect(getComputedStyle(button).fontSize).toBe(SHADCN_NEW_YORK_V4_COMPUTED.controlFontSize);
-    expect(px(getComputedStyle(input).minHeight)).toBe(SHADCN_NEW_YORK_V4_COMPUTED.inputHeight);
+    expect(px(getComputedStyle(button).minHeight)).toBe(DEFAULT_VISUAL_BASELINE.buttonHeight);
+    expect(getComputedStyle(button).fontSize).toBe(DEFAULT_VISUAL_BASELINE.controlFontSize);
+    expect(px(getComputedStyle(input).minHeight)).toBe(DEFAULT_VISUAL_BASELINE.inputHeight);
     expect(getComputedStyle(input).backgroundColor).toBe("rgba(0, 0, 0, 0)");
-    expect(px(getComputedStyle(card).borderTopLeftRadius)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.cardRadius,
-    );
+    expect(px(getComputedStyle(card).borderTopLeftRadius)).toBe(DEFAULT_VISUAL_BASELINE.cardRadius);
     expect(getComputedStyle(dialog).boxShadow).not.toBe("none");
     expect(px(getComputedStyle(dropdownItem).minHeight)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.menuRowHeight,
+      DEFAULT_VISUAL_BASELINE.menuRowHeight,
     );
-    expect(px(getComputedStyle(selectItem).minHeight)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.menuRowHeight,
-    );
+    expect(px(getComputedStyle(selectItem).minHeight)).toBe(DEFAULT_VISUAL_BASELINE.menuRowHeight);
     expect(px(getComputedStyle(tabsTrigger).minHeight)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.tabsTriggerHeight,
+      DEFAULT_VISUAL_BASELINE.tabsTriggerHeight,
     );
     expect(getComputedStyle(tooltip).fontSize).toBe("12px");
   });
 
-  it("should deepen sheet and sidebar anatomy with shadcn-like computed styles", () => {
+  it("should deepen sheet and sidebar anatomy with default theme computed styles", () => {
     document.body.innerHTML = `
       <section data-slot="sheet-content" data-side="right">
         <header data-slot="sheet-header">
@@ -105,17 +101,17 @@ describe("shadcn New York visual parity", () => {
     const label = document.querySelector('[data-slot="sidebar-group-label"]') as HTMLElement;
 
     expect(getComputedStyle(sheet).position).toBe("fixed");
-    expect(px(getComputedStyle(sheet).width)).toBe(SHADCN_NEW_YORK_V4_COMPUTED.sheetWidth);
+    expect(px(getComputedStyle(sheet).width)).toBe(DEFAULT_VISUAL_BASELINE.sheetWidth);
     expect(getComputedStyle(scope).display).toBe("flex");
     expect(getComputedStyle(sidebar).display).toBe("flex");
     expect(px(getComputedStyle(button).minHeight)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.sidebarMenuButtonHeight,
+      DEFAULT_VISUAL_BASELINE.sidebarMenuButtonHeight,
     );
     expectNotTransparent(getComputedStyle(button).backgroundColor, "active sidebar menu button");
     expect(getComputedStyle(label).fontSize).toBe("12px");
   });
 
-  it("should deepen command, calendar, and item states to shadcn-like surfaces", () => {
+  it("should deepen command, calendar, and item states to default theme surfaces", () => {
     document.body.innerHTML = `
       <div data-slot="command-dialog">
         <div data-slot="command-header">
@@ -171,22 +167,20 @@ describe("shadcn New York visual parity", () => {
     expect(getComputedStyle(command).boxShadow).not.toBe("none");
     expect(getComputedStyle(commandHeading).fontSize).toBe("12px");
     expect(px(getComputedStyle(commandSelected).minHeight)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.commandRowHeight,
+      DEFAULT_VISUAL_BASELINE.commandRowHeight,
     );
     expectNotTransparent(
       getComputedStyle(commandSelected).backgroundColor,
       "selected command item",
     );
-    expect(getComputedStyle(commandDisabled).opacity).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.disabledOpacity,
-    );
+    expect(getComputedStyle(commandDisabled).opacity).toBe(DEFAULT_VISUAL_BASELINE.disabledOpacity);
     expect(px(getComputedStyle(calendarDay).minHeight)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.calendarDaySize,
+      DEFAULT_VISUAL_BASELINE.calendarDaySize,
     );
     expectNotTransparent(getComputedStyle(calendarDay).backgroundColor, "selected calendar day");
-    expect(getComputedStyle(disabledDay).opacity).toBe(SHADCN_NEW_YORK_V4_COMPUTED.disabledOpacity);
+    expect(getComputedStyle(disabledDay).opacity).toBe(DEFAULT_VISUAL_BASELINE.disabledOpacity);
     expect(px(getComputedStyle(item).paddingBlockStart)).toBe(
-      SHADCN_NEW_YORK_V4_COMPUTED.itemXsPaddingBlock,
+      DEFAULT_VISUAL_BASELINE.itemXsPaddingBlock,
     );
     expectNotTransparent(getComputedStyle(item).backgroundColor, "active item");
   });

--- a/tests/fixtures/default-visual-baseline.ts
+++ b/tests/fixtures/default-visual-baseline.ts
@@ -1,4 +1,4 @@
-export const SHADCN_NEW_YORK_V4_COMPUTED = {
+export const DEFAULT_VISUAL_BASELINE = {
   buttonHeight: 36,
   calendarDaySize: 32,
   cardRadius: 12,

--- a/tests/unit/component-coverage.test.ts
+++ b/tests/unit/component-coverage.test.ts
@@ -5,9 +5,9 @@ import { describe, expect, it } from "vite-plus/test";
 
 import * as components from "../../src/components";
 import {
-  SHADCN_CHART_COMPONENT,
-  SHADCN_THEME_COMPONENT_SUBPATHS,
-  SHADCN_THEME_COMPONENTS,
+  EXCLUDED_CHART_COMPONENT,
+  THEME_COMPONENT_SUBPATHS,
+  THEME_COMPONENTS,
 } from "../../src/parity";
 import { ROOT_DIR } from "./test-paths";
 
@@ -29,21 +29,21 @@ function assertFileExists(relativePath: string, message: string): void {
 }
 
 describe("component coverage matrix", () => {
-  it("should keeps every non-chart shadcn component represented in the themes catalog", () => {
+  it("should keeps every public non-chart component represented in the themes catalog", () => {
     const namespace = components as Record<string, unknown>;
 
-    for (const component of SHADCN_THEME_COMPONENTS) {
+    for (const component of THEME_COMPONENTS) {
       expect(typeof namespace[component], component).toBe("function");
     }
 
-    expect(namespace[SHADCN_CHART_COMPONENT]).toBeUndefined();
+    expect(namespace[EXCLUDED_CHART_COMPONENT]).toBeUndefined();
   });
 
-  it("should keeps every non-chart shadcn component represented by a package subpath", () => {
-    expect(SHADCN_THEME_COMPONENT_SUBPATHS).not.toContain("chart");
-    expect(SHADCN_THEME_COMPONENT_SUBPATHS).not.toContain("charts");
+  it("should keeps every public non-chart component represented by a package subpath", () => {
+    expect(THEME_COMPONENT_SUBPATHS).not.toContain("chart");
+    expect(THEME_COMPONENT_SUBPATHS).not.toContain("charts");
 
-    for (const subpath of SHADCN_THEME_COMPONENT_SUBPATHS) {
+    for (const subpath of THEME_COMPONENT_SUBPATHS) {
       expect(typeof subpath).toBe("string");
       expect(subpath.length).toBeGreaterThan(0);
     }

--- a/tests/unit/docs-surface.test.ts
+++ b/tests/unit/docs-surface.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 
@@ -9,6 +9,15 @@ const README = join(ROOT_DIR, "README.md");
 const THEMES_DOC = join(DOCS_DIR, "askr-themes.md");
 const THEMING_DOC = join(DOCS_DIR, "theming.md");
 const ARCHITECTURE_DOC = join(DOCS_DIR, "architecture.md");
+const ACKNOWLEDGEMENTS = join(DOCS_DIR, "acknowledgements.md");
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(path);
+    return /\.(?:css|ts|tsx)$/u.test(entry.name) ? [path] : [];
+  });
+}
 
 describe("docs surface", () => {
   it("should documents the component catalog package surface", () => {
@@ -54,5 +63,23 @@ describe("docs surface", () => {
     expect(THEME_COMPONENT_SUBPATHS).not.toContain("chart");
     expect(THEME_COMPONENT_SUBPATHS).not.toContain("charts");
     expect(EXCLUDED_CHART_COMPONENT).toBe("Chart");
+  });
+
+  it("should keeps external project attribution in acknowledgements, not source or tests", () => {
+    const acknowledgements = readFileSync(ACKNOWLEDGEMENTS, "utf-8");
+    const externalProjectNames = [...acknowledgements.matchAll(/^- \[([^\]]+)\]/gmu)].map(
+      ([, name]) => name,
+    );
+
+    expect(externalProjectNames.length).toBeGreaterThan(0);
+    for (const file of [
+      ...sourceFiles(join(ROOT_DIR, "src")),
+      ...sourceFiles(join(ROOT_DIR, "tests")),
+    ]) {
+      const source = readFileSync(file, "utf-8").toLowerCase();
+      for (const projectName of externalProjectNames) {
+        expect(source, file).not.toContain(projectName.toLowerCase());
+      }
+    }
   });
 });

--- a/tests/unit/docs-surface.test.ts
+++ b/tests/unit/docs-surface.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 
-import { SHADCN_CHART_COMPONENT, SHADCN_THEME_COMPONENT_SUBPATHS } from "../../src/parity";
+import { EXCLUDED_CHART_COMPONENT, THEME_COMPONENT_SUBPATHS } from "../../src/parity";
 import { DOCS_DIR, PACKAGE_JSON, ROOT_DIR } from "./test-paths";
 
 const README = join(ROOT_DIR, "README.md");
@@ -45,14 +45,14 @@ describe("docs surface", () => {
     expect(docs).not.toContain("@askrjs/themes/overlays");
   });
 
-  it("should documents non-chart shadcn parity without moving charts into themes", () => {
+  it("should documents catalog coverage without moving charts into themes", () => {
     const readme = readFileSync(README, "utf-8");
     const themingDoc = readFileSync(THEMING_DOC, "utf-8");
 
-    expect(readme).toContain("shadcn-style");
+    expect(readme).toContain("styled component catalog");
     expect(themingDoc).toMatch(/Chart components stay\s+in `@askrjs\/charts`/);
-    expect(SHADCN_THEME_COMPONENT_SUBPATHS).not.toContain("chart");
-    expect(SHADCN_THEME_COMPONENT_SUBPATHS).not.toContain("charts");
-    expect(SHADCN_CHART_COMPONENT).toBe("Chart");
+    expect(THEME_COMPONENT_SUBPATHS).not.toContain("chart");
+    expect(THEME_COMPONENT_SUBPATHS).not.toContain("charts");
+    expect(EXCLUDED_CHART_COMPONENT).toBe("Chart");
   });
 });

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -6,9 +6,9 @@ import { describe, expect, it } from "vite-plus/test";
 
 import * as components from "../../src/components";
 import {
-  SHADCN_CHART_COMPONENT,
-  SHADCN_THEME_COMPONENT_SUBPATHS,
-  SHADCN_THEME_COMPONENTS,
+  EXCLUDED_CHART_COMPONENT,
+  THEME_COMPONENT_SUBPATHS,
+  THEME_COMPONENTS,
 } from "../../src/parity";
 import { ThemePicker, ThemeScope, ThemeToggle } from "../../src/theme";
 import {
@@ -136,14 +136,14 @@ function hasModuleBinding(bindings: ReadonlySet<string>, name: string): boolean 
 }
 
 describe("package surface", () => {
-  it("should exposes the shadcn-style component catalog from the aggregate entrypoint", () => {
+  it("should exposes the styled component catalog from the aggregate entrypoint", () => {
     const namespace = components as Record<string, unknown>;
 
-    for (const component of SHADCN_THEME_COMPONENTS) {
+    for (const component of THEME_COMPONENTS) {
       expect(typeof namespace[component], component).toBe("function");
     }
 
-    expect(namespace[SHADCN_CHART_COMPONENT]).toBeUndefined();
+    expect(namespace[EXCLUDED_CHART_COMPONENT]).toBeUndefined();
     expect(typeof ThemeScope).toBe("function");
     expect(typeof ThemePicker).toBe("function");
     expect(typeof ThemeToggle).toBe("function");
@@ -196,7 +196,7 @@ describe("package surface", () => {
     expect(pkg.exports?.["./chart"]).toBeUndefined();
     expect(pkg.exports?.["./charts"]).toBeUndefined();
 
-    for (const subpath of SHADCN_THEME_COMPONENT_SUBPATHS) {
+    for (const subpath of THEME_COMPONENT_SUBPATHS) {
       expect(pkg.exports?.[`./${subpath}`], subpath).toBeUndefined();
     }
 
@@ -205,7 +205,7 @@ describe("package surface", () => {
         .filter((entry) => entry.endsWith(".ts"))
         .map((entry) => entry.slice(0, -3))
         .sort(),
-    ).toEqual([...SHADCN_THEME_COMPONENT_SUBPATHS].sort());
+    ).toEqual([...THEME_COMPONENT_SUBPATHS].sort());
 
     for (const entrypoint of REMOVED_FAMILY_EXPORTS) {
       expect(pkg.exports?.[entrypoint], entrypoint).toBeUndefined();

--- a/tests/unit/tokens.test.ts
+++ b/tests/unit/tokens.test.ts
@@ -567,9 +567,9 @@ describe("token completeness", () => {
     expect(aliasReferences).toEqual([]);
   });
 
-  it("should keep shadcn-compatible semantic tokens behind the ak namespace", () => {
+  it("should keep theme semantic tokens behind the ak namespace", () => {
     const tokensCss = readFileSync(TOKENS_FILE, "utf-8");
-    const forbiddenShadcnAliases = [
+    const forbiddenUnnamespacedAliases = [
       "--background",
       "--foreground",
       "--card",
@@ -590,7 +590,7 @@ describe("token completeness", () => {
       "--ring",
     ];
 
-    for (const token of forbiddenShadcnAliases) {
+    for (const token of forbiddenUnnamespacedAliases) {
       expect(tokensCss).not.toContain(`${token}:`);
     }
 

--- a/tests/unit/visual-quality-contract.test.ts
+++ b/tests/unit/visual-quality-contract.test.ts
@@ -104,7 +104,7 @@ describe("visual quality contract", () => {
     expect(rootTheming).toContain("templates/theme/styles");
   });
 
-  it("should keep shared primitives visually aligned with shadcn generated defaults", () => {
+  it("should keep shared primitives visually aligned with the default theme baseline", () => {
     expect(buttonCss).toContain("--_button-height: var(--ak-density-control-height-md);");
     expect(buttonCss).toContain("background: var(--ak-color-primary);");
     expect(buttonCss).toContain("font-weight: var(--ak-font-weight-medium);");


### PR DESCRIPTION
## Summary
- remove SHADCN references from source, tests, fixtures, and documentation
- rename catalog coverage constants to package-native terminology
- rename the visual baseline fixture and browser suite

## Verification
- `npm run check`
- repository-wide case-insensitive reference scan is empty