### PR TITLE
chore: require Node 24 and npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@askrjs/ui": ">=0.0.24 <0.1.0"
   },
   "engines": {
-    "node": ">=24.15.0"
+    "node": ">=24.0.0"
   },
-  "packageManager": "npm@11.17.0"
+  "packageManager": "npm@12.0.1"
 }


### PR DESCRIPTION
Standardizes the package metadata on Node 24 and npm 12:

- Sets `engines.node` to `>=24.0.0`.
- Pins the package manager to `npm@12.0.1`.

This keeps the package contract aligned with the current Node LTS CI policy.