### PR TITLE
chore: release v0.0.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.21",
+      "version": "0.0.22",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.85 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",


### PR DESCRIPTION
Release v0.0.22 with the Node.js 24 and npm 12 package metadata updates.