### PR TITLE
docs: add theme capability guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+Operational guide for contributors to `@askrjs/themes`.
+
+## Scope
+
+This repository owns Askr design tokens, default CSS themes, component
+presets, and theme helpers. Keep token names and generated package entrypoints
+backward compatible.
+
+## Ground rules
+
+1. Prefer token and composition changes over component-specific overrides.
+2. Keep CSS, TypeScript helpers, README/THEMING.md, and package exports aligned.
+3. Add regression coverage for changed theme contracts or generated bundles.
+4. Do not hardcode theme tokens in runtime packages.
+
+## Validation
+
+Run `npm run check` before opening a pull request.

--- a/capabilities.json
+++ b/capabilities.json
@@ -6,8 +6,15 @@
       "intent": "default design tokens and CSS theme",
       "package": "@askrjs/themes",
       "import": "@askrjs/themes/default",
-      "exports": ["tokens.css", "foundations.css", "styles/*"],
-      "constraints": ["theme tokens are CSS custom properties", "CSS imports are side-effectful"],
+      "exports": [
+        "tokens.css",
+        "foundations.css",
+        "styles/*"
+      ],
+      "constraints": [
+        "theme tokens are CSS custom properties",
+        "CSS imports are side-effectful"
+      ],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
       "docsPath": "THEMING.md"
@@ -16,8 +23,16 @@
       "intent": "component presets and layout helpers",
       "package": "@askrjs/themes",
       "import": "@askrjs/themes/components",
-      "exports": ["EmptyState", "Spinner", "Badge", "Stack", "Button"],
-      "constraints": ["presets compose headless @askrjs/ui primitives"],
+      "exports": [
+        "EmptyState",
+        "Spinner",
+        "Badge",
+        "Stack",
+        "Button"
+      ],
+      "constraints": [
+        "presets compose headless @askrjs/ui primitives"
+      ],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
       "docsPath": "THEMING.md"
@@ -26,8 +41,13 @@
       "intent": "theme runtime and SSR helpers",
       "package": "@askrjs/themes",
       "import": "@askrjs/themes/theme",
-      "exports": ["createTheme", "resolveTheme"],
-      "constraints": ["theme selection must be deterministic during SSR"],
+      "exports": [
+        "createTheme",
+        "resolveTheme"
+      ],
+      "constraints": [
+        "theme selection must be deterministic during SSR"
+      ],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
       "docsPath": "THEMING.md"

--- a/capabilities.json
+++ b/capabilities.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "package": "@askrjs/themes",
+  "capabilities": [
+    {
+      "intent": "default design tokens and CSS theme",
+      "package": "@askrjs/themes",
+      "import": "@askrjs/themes/default",
+      "exports": ["tokens.css", "foundations.css", "styles/*"],
+      "constraints": ["theme tokens are CSS custom properties", "CSS imports are side-effectful"],
+      "stability": "stable",
+      "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
+      "docsPath": "THEMING.md"
+    },
+    {
+      "intent": "component presets and layout helpers",
+      "package": "@askrjs/themes",
+      "import": "@askrjs/themes/components",
+      "exports": ["EmptyState", "Spinner", "Badge", "Stack", "Button"],
+      "constraints": ["presets compose headless @askrjs/ui primitives"],
+      "stability": "stable",
+      "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
+      "docsPath": "THEMING.md"
+    },
+    {
+      "intent": "theme runtime and SSR helpers",
+      "package": "@askrjs/themes",
+      "import": "@askrjs/themes/theme",
+      "exports": ["createTheme", "resolveTheme"],
+      "constraints": ["theme selection must be deterministic during SSR"],
+      "stability": "stable",
+      "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
+      "docsPath": "THEMING.md"
+    }
+  ]
+}

--- a/capabilities.json
+++ b/capabilities.json
@@ -6,15 +6,8 @@
       "intent": "default design tokens and CSS theme",
       "package": "@askrjs/themes",
       "import": "@askrjs/themes/default",
-      "exports": [
-        "tokens.css",
-        "foundations.css",
-        "styles/*"
-      ],
-      "constraints": [
-        "theme tokens are CSS custom properties",
-        "CSS imports are side-effectful"
-      ],
+      "exports": ["tokens.css", "foundations.css", "styles/*"],
+      "constraints": ["theme tokens are CSS custom properties", "CSS imports are side-effectful"],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
       "docsPath": "THEMING.md"
@@ -23,16 +16,8 @@
       "intent": "component presets and layout helpers",
       "package": "@askrjs/themes",
       "import": "@askrjs/themes/components",
-      "exports": [
-        "EmptyState",
-        "Spinner",
-        "Badge",
-        "Stack",
-        "Button"
-      ],
-      "constraints": [
-        "presets compose headless @askrjs/ui primitives"
-      ],
+      "exports": ["EmptyState", "Spinner", "Badge", "Stack", "Button"],
+      "constraints": ["presets compose headless @askrjs/ui primitives"],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
       "docsPath": "THEMING.md"
@@ -41,13 +26,8 @@
       "intent": "theme runtime and SSR helpers",
       "package": "@askrjs/themes",
       "import": "@askrjs/themes/theme",
-      "exports": [
-        "createTheme",
-        "resolveTheme"
-      ],
-      "constraints": [
-        "theme selection must be deterministic during SSR"
-      ],
+      "exports": ["createTheme", "resolveTheme"],
+      "constraints": ["theme selection must be deterministic during SSR"],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-themes/blob/main/THEMING.md",
       "docsPath": "THEMING.md"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "git+https://github.com/askrjs/askr-themes.git"
   },
   "files": [
+    "capabilities.json",
     "dist",
     "src",
     "templates",
@@ -86,7 +87,8 @@
       "types": "./src/css.d.ts",
       "default": "./templates/*"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./capabilities.json": "./capabilities.json"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Closes #50. Adds AGENTS.md and a published capabilities.json covering tokens, presets, and theme helpers.

Validation: JSON/package metadata validation.