### PR TITLE
chore: release v0.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.85 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",

--- a/tests/installed-types.js
+++ b/tests/installed-types.js
@@ -19,14 +19,15 @@ try {
     return version;
   };
 
-  const packResult = JSON.parse(
+  const packOutput = JSON.parse(
     execFileSync(npm, ["pack", "--ignore-scripts", "--json", "--pack-destination", consumerRoot], {
       cwd: repositoryRoot,
       encoding: "utf8",
       shell: process.platform === "win32",
     }),
   );
-  const tarball = join(consumerRoot, packResult[0].filename);
+  const packResult = Array.isArray(packOutput) ? packOutput[0] : Object.values(packOutput)[0];
+  const tarball = join(consumerRoot, packResult.filename);
 
   writeFileSync(
     join(consumerRoot, "package.json"),


### PR DESCRIPTION
Patch release to v0.0.23. Includes package metadata/version updates and npm 12-compatible artifact checks where required. Local release gate is green.