### PR TITLE
fix: preserve false ARIA props in theme components

### DIFF
--- a/src/components/_internal/jsx.ts
+++ b/src/components/_internal/jsx.ts
@@ -3,12 +3,22 @@ import { jsx, type JSX } from "@askrjs/askr/jsx-runtime";
 
 const renderIntrinsicElement = jsx as (type: string, props: Record<string, unknown>) => JSX.Element;
 
+export function normalizeAriaProps(props: Record<string, unknown>): Record<string, unknown> {
+  const normalized = { ...props };
+  for (const key of Object.keys(normalized)) {
+    if (key.startsWith("aria-") && typeof normalized[key] === "boolean") {
+      normalized[key] = String(normalized[key]);
+    }
+  }
+  return normalized;
+}
+
 export function intrinsicElement(
   type: string,
   props: Record<string, unknown>,
   children: unknown,
 ): JSX.Element {
-  return renderIntrinsicElement(type, { ...props, children });
+  return renderIntrinsicElement(type, { ...normalizeAriaProps(props), children });
 }
 
 export function isJsxElement(value: unknown): value is JSXElement {

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -3,7 +3,7 @@ import { Slot } from "@askrjs/askr/foundations";
 import { Block } from "../block";
 import { classes } from "../_internal/classes";
 import { mergeProps } from "../_internal/merge-props";
-import { intrinsicElement } from "../_internal/jsx";
+import { intrinsicElement, normalizeAriaProps } from "../_internal/jsx";
 import type {
   SidebarButtonProps,
   SidebarPartProps,
@@ -27,7 +27,7 @@ function sidebarPart(
   element: keyof JSX.IntrinsicElements = "div",
 ): JSX.Element {
   const { as, asChild, children, class: className, ...rest } = props;
-  const finalProps = mergeProps(rest, {
+  const finalProps = mergeProps(normalizeAriaProps(rest), {
     class: className,
     "data-slot": slot,
   });
@@ -123,7 +123,7 @@ export function SidebarMenuButton(props: SidebarButtonProps): JSX.Element {
     variant,
     ...rest
   } = props;
-  const finalProps = mergeProps(rest, {
+  const finalProps = mergeProps(normalizeAriaProps(rest), {
     class: classes(className),
     "data-active": active ? "true" : undefined,
     "data-size": size && size !== "default" ? size : undefined,
@@ -153,7 +153,7 @@ export function SidebarMenuAction(props: SidebarButtonProps): JSX.Element {
     type = "button",
     ...rest
   } = props;
-  const finalProps = mergeProps(rest, {
+  const finalProps = mergeProps(normalizeAriaProps(rest), {
     class: classes(className),
     "data-slot": "sidebar-menu-action",
     ...sidebarTooltipProps(tooltip, tooltipSide),
@@ -172,7 +172,7 @@ export function SidebarMenuBadge(props: SidebarPartProps): JSX.Element {
 
 export function SidebarRail(props: SidebarButtonProps): JSX.Element {
   const { asChild, children, class: className, type = "button", ...rest } = props;
-  const finalProps = mergeProps(rest, {
+  const finalProps = mergeProps(normalizeAriaProps(rest), {
     class: classes(className),
     "data-slot": "sidebar-rail",
   });
@@ -194,7 +194,7 @@ export function SidebarTrigger(props: SidebarButtonProps): JSX.Element {
     type = "button",
     ...rest
   } = props;
-  const finalProps = mergeProps(rest, {
+  const finalProps = mergeProps(normalizeAriaProps(rest), {
     class: classes("btn btn-ghost btn-icon", className),
     "data-slot": "sidebar-trigger",
     ...sidebarTooltipProps(tooltip, tooltipSide),

--- a/tests/browser/navbar.test.tsx
+++ b/tests/browser/navbar.test.tsx
@@ -14,6 +14,7 @@ import {
   NavLink,
   Navbar,
 } from "../../src/core";
+import { SidebarMenuButton } from "../../src/components/sidebar";
 import { DropdownItem } from "../../src/overlays";
 
 import "../../src/themes/default/index.css";
@@ -60,6 +61,21 @@ describe("navbar browser smoke", () => {
     }
 
     resetTestRoutes();
+  });
+
+  it("should preserve explicit false ARIA state through theme controls", async () => {
+    testRoute("/docs", () => (
+      <div>
+        <SidebarMenuButton aria-expanded={false}>Database</SidebarMenuButton>
+      </div>
+    ));
+
+    await createSPA({ root: container!, registry: createTestRegistry() });
+    await settle();
+
+    const controls = container?.querySelectorAll("[aria-expanded]");
+    expect(controls).toHaveLength(1);
+    expect(controls?.[0]?.getAttribute("aria-expanded")).toBe("false");
   });
 
   it("should renders semantic navbar structure with Block layout styles", async () => {


### PR DESCRIPTION
Part of #53; paired with askrjs/askr-ui#45

## Summary
- normalize boolean `aria-*` props before theme intrinsic rendering
- apply the same normalization to sidebar button/rail/trigger wrappers
- add a cross-browser regression for `aria-expanded={false}`

## Validation
- Chromium, Firefox, and WebKit navbar browser suite: passed