### PR TITLE
test: correct test name grammar

### DIFF
--- a/tests/browser/navbar-link.test.tsx
+++ b/tests/browser/navbar-link.test.tsx
@@ -30,7 +30,7 @@ describe("navbar link browser smoke", () => {
     resetTestRoutes();
   });
 
-  it("should updates active NavLink state across client-side navigation inside a persistent layout", async () => {
+  it("should update active NavLink state across client-side navigation inside a persistent layout", async () => {
     function DocsLayout({ children }: { children?: unknown }) {
       return (
         <>

--- a/tests/browser/navbar.test.tsx
+++ b/tests/browser/navbar.test.tsx
@@ -78,7 +78,7 @@ describe("navbar browser smoke", () => {
     expect(controls?.[0]?.getAttribute("aria-expanded")).toBe("false");
   });
 
-  it("should renders semantic navbar structure with Block layout styles", async () => {
+  it("should render semantic navbar structure with Block layout styles", async () => {
     testRoute("/docs", () => (
       <Header sticky>
         <Container>
@@ -136,7 +136,7 @@ describe("navbar browser smoke", () => {
     expect(container?.querySelector("#page")?.textContent).toBe("Components");
   });
 
-  it("should centers primary routes between brand and end actions", async () => {
+  it("should center primary routes between brand and end actions", async () => {
     testRoute("/docs", () => (
       <Header sticky>
         <Container>
@@ -227,7 +227,7 @@ describe("navbar browser smoke", () => {
     expect(getComputedStyle(brand!).overflow).toBe("hidden");
   });
 
-  it("should switches responsive navbar between collapsed and inline content", async () => {
+  it("should switch responsive navbar between collapsed and inline content", async () => {
     const ResponsiveNav = () => (
       <Navbar aria-label="Responsive docs navigation" collapseAt="md">
         <NavBrand asChild>
@@ -309,7 +309,7 @@ describe("navbar browser smoke", () => {
     );
   });
 
-  it("should opens NavDropdown with route-aware NavLink children", async () => {
+  it("should open NavDropdown with route-aware NavLink children", async () => {
     testRoute("/docs", () => (
       <Navbar aria-label="Dropdown docs navigation">
         <NavBrand as="a" href="/">

--- a/tests/browser/public-family-smoke.test.tsx
+++ b/tests/browser/public-family-smoke.test.tsx
@@ -61,7 +61,7 @@ describe("public family browser smoke", () => {
     resetTestRoutes();
   });
 
-  it("should renders the remaining public families in a browser mount", async () => {
+  it("should render the remaining public families in a browser mount", async () => {
     testRoute("/families", () => (
       <Page>
         <Header sticky>

--- a/tests/browser/sidebar.test.tsx
+++ b/tests/browser/sidebar.test.tsx
@@ -38,7 +38,7 @@ describe("sidebar browser smoke", () => {
     resetTestRoutes();
   });
 
-  it("should renders sidebar as a semantic Block preset beside main content", async () => {
+  it("should render sidebar as a semantic Block preset beside main content", async () => {
     testRoute("/docs", () => (
       <Block minHeight="screen" direction="row">
         <Sidebar aria-label="Workspace navigation">

--- a/tests/browser/spinner.test.tsx
+++ b/tests/browser/spinner.test.tsx
@@ -30,7 +30,7 @@ describe("spinner browser smoke", () => {
     resetTestRoutes();
   });
 
-  it("should renders spinner sizing", async () => {
+  it("should render spinner sizing", async () => {
     testRoute("/status", () => (
       <div>
         <Spinner label="Syncing" />

--- a/tests/browser/table-theme.test.tsx
+++ b/tests/browser/table-theme.test.tsx
@@ -38,7 +38,7 @@ describe("table theme smoke test", () => {
     resetTestRoutes();
   });
 
-  it("should styles the semantic table primitives through the default theme bundle", async () => {
+  it("should style the semantic table primitives through the default theme bundle", async () => {
     testRoute("/table", () => (
       <Table aria-label="Users">
         <TableHead>

--- a/tests/browser/theme-route-persistence.test.tsx
+++ b/tests/browser/theme-route-persistence.test.tsx
@@ -37,7 +37,7 @@ describe("theme route persistence in the browser", () => {
     document.documentElement.removeAttribute("data-theme-choice");
   });
 
-  it("should preserves theme state across navigation and repeated toggles", async () => {
+  it("should preserve theme state across navigation and repeated toggles", async () => {
     const AppLayout = ({ children }: { children?: unknown }) => (
       <ThemeScope defaultTheme="light">
         <header>
@@ -110,7 +110,7 @@ describe("theme route persistence in the browser", () => {
     expect(window.localStorage.getItem("askr-theme")).toBe("light");
   });
 
-  it("should preserves cat preset theme state across navigation and repeated toggles", async () => {
+  it("should preserve cat preset theme state across navigation and repeated toggles", async () => {
     const AppLayout = ({ children }: { children?: unknown }) => (
       <ThemeScope defaultTheme="tabby" themes={CAT_THEME_OPTIONS}>
         <header>

--- a/tests/browser/visual-polish.test.tsx
+++ b/tests/browser/visual-polish.test.tsx
@@ -30,7 +30,7 @@ describe("visual polish contracts", () => {
     document.body.innerHTML = "";
   });
 
-  it("should keeps core interactive controls on one shared density rhythm", () => {
+  it("should keep core interactive controls on one shared density rhythm", () => {
     document.body.innerHTML = `
       <button class="btn" data-slot="button">Save</button>
       <input class="input" data-slot="input" value="hello" />
@@ -53,7 +53,7 @@ describe("visual polish contracts", () => {
     }
   });
 
-  it("should keeps dropdown and select rows aligned and compact", () => {
+  it("should keep dropdown and select rows aligned and compact", () => {
     document.body.innerHTML = `
       <div data-slot="dropdown-content">
         <button data-slot="dropdown-item">Profile</button>
@@ -96,7 +96,7 @@ describe("visual polish contracts", () => {
     expect(style.textAlign).toBe("start");
   });
 
-  it("should keeps dark overlay surfaces dark, elevated, and readable", () => {
+  it("should keep dark overlay surfaces dark, elevated, and readable", () => {
     document.documentElement.setAttribute("data-theme", "dark");
     document.body.innerHTML = `
       <section data-slot="dialog-content">
@@ -128,7 +128,7 @@ describe("visual polish contracts", () => {
     }
   });
 
-  it("should protects dense surfaces from collapsed spacing and long-label overflow", () => {
+  it("should protect dense surfaces from collapsed spacing and long-label overflow", () => {
     document.body.innerHTML = `
       <article class="card" data-slot="card">
         <h3>A long card title that needs polish</h3>
@@ -176,7 +176,7 @@ describe("visual polish contracts", () => {
     }
   });
 
-  it("should gives disclosure and scroll primitives usable default polish", () => {
+  it("should give disclosure and scroll primitives usable default polish", () => {
     document.body.innerHTML = `
       <div data-slot="accordion">
         <div data-slot="accordion-item" data-state="open">
@@ -207,7 +207,7 @@ describe("visual polish contracts", () => {
     expect(viewport.scrollHeight).toBeGreaterThan(viewport.clientHeight);
   });
 
-  it("should gives slider, toggles, hover cards, and menubars usable default polish", () => {
+  it("should give slider, toggles, hover cards, and menubars usable default polish", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <div data-slot="slider" data-orientation="horizontal" style="--ak-slider-percentage: 60%;">
@@ -286,7 +286,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(menubarSubTrigger).textDecorationLine).toBe("none");
   });
 
-  it("should gives virtualized list and table surfaces stable default polish", () => {
+  it("should give virtualized list and table surfaces stable default polish", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <div data-slot="virtual-list" data-viewport="lg">
@@ -370,7 +370,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(wrappedText).overflowWrap).toBe("anywhere");
   });
 
-  it("should keeps supporting primitives compact, responsive, and aligned", () => {
+  it("should keep supporting primitives compact, responsive, and aligned", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <span class="avatar" data-slot="avatar">
@@ -433,7 +433,7 @@ describe("visual polish contracts", () => {
     expect(themePicker.getBoundingClientRect().height).toBeGreaterThanOrEqual(36);
   });
 
-  it("should keeps status, loading, and media primitives resilient under long content", () => {
+  it("should keep status, loading, and media primitives resilient under long content", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <span class="badge" data-slot="badge" data-variant="info">
@@ -507,7 +507,7 @@ describe("visual polish contracts", () => {
     expect(px(getComputedStyle(spinner).width)).toBe(36);
   });
 
-  it("should keeps the manual audit page overflow-free from mobile through desktop widths", async () => {
+  it("should keep the manual audit page overflow-free from mobile through desktop widths", async () => {
     for (const width of [320, 390, 768, 1024, 1440]) {
       document.body.innerHTML = "";
       const iframe = await loadAuditFrame(width);
@@ -531,7 +531,7 @@ describe("visual polish contracts", () => {
     }
   }, 60_000);
 
-  it("should keeps constrained desktop navbar brand and actions visible", async () => {
+  it("should keep constrained desktop navbar brand and actions visible", async () => {
     document.body.innerHTML = "";
     const iframe = await loadAuditFrame(1024);
     const doc = iframe.contentDocument!;
@@ -554,7 +554,7 @@ describe("visual polish contracts", () => {
     expect(action.getBoundingClientRect().width).toBeGreaterThanOrEqual(36);
   });
 
-  it("should keeps manual audit navbar collapsed and readable on mobile", async () => {
+  it("should keep manual audit navbar collapsed and readable on mobile", async () => {
     document.body.innerHTML = "";
     const iframe = await loadAuditFrame(320);
     const doc = iframe.contentDocument!;
@@ -575,7 +575,7 @@ describe("visual polish contracts", () => {
     expect(content.scrollWidth).toBeLessThanOrEqual(navbar.clientWidth);
   });
 
-  it("should keeps table density readable inside the mobile audit width", async () => {
+  it("should keep table density readable inside the mobile audit width", async () => {
     document.body.innerHTML = "";
     const iframe = await loadAuditFrame(320);
     const doc = iframe.contentDocument!;
@@ -593,7 +593,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(headerCell).letterSpacing).toBe("normal");
   });
 
-  it("should keeps oversized block presets inside narrow containers", () => {
+  it("should keep oversized block presets inside narrow containers", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <div data-slot="block">
@@ -610,7 +610,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(block).gridTemplateColumns).not.toContain("480px");
   });
 
-  it("should keeps mobile overlays and horizontal groups within a 320px surface", () => {
+  it("should keep mobile overlays and horizontal groups within a 320px surface", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <section data-slot="dialog-content">
@@ -666,7 +666,7 @@ describe("visual polish contracts", () => {
     expect(px(getComputedStyle(popoverContent).width)).toBeGreaterThan(220);
   });
 
-  it("should keeps overlay motion states stable and non-interactive while closing", () => {
+  it("should keep overlay motion states stable and non-interactive while closing", () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <div data-slot="dialog-overlay" data-state="closed"></div>
@@ -719,7 +719,7 @@ describe("visual polish contracts", () => {
     ).toBe("anywhere");
   });
 
-  it("should keeps semantic navigation slots compact and contained", () => {
+  it("should keep semantic navigation slots compact and contained", () => {
     document.body.innerHTML = `
       <nav data-slot="navbar">
         <div data-slot="nav-group">
@@ -754,7 +754,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(active).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
   });
 
-  it("should keeps page header and toolbar action rows wrap-safe", () => {
+  it("should keep page header and toolbar action rows wrap-safe", () => {
     document.body.innerHTML = `
       <header data-slot="page-header">
         <div data-slot="page-header-copy">

--- a/tests/jsdom/aspect-ratio.test.tsx
+++ b/tests/jsdom/aspect-ratio.test.tsx
@@ -12,7 +12,7 @@ function asElement(value: unknown): ElementLike {
 }
 
 describe("AspectRatio", () => {
-  it("should renders a canonical wrapper with a generated ratio class", () => {
+  it("should render a canonical wrapper with a generated ratio class", () => {
     const element = asElement(AspectRatio({ ratio: 16 / 9, children: "media" }));
 
     expect(element.type).toBe("div");
@@ -21,7 +21,7 @@ describe("AspectRatio", () => {
     expect(String(element.props.class)).toContain("ak-style-");
   });
 
-  it("should supports asChild composition", () => {
+  it("should support asChild composition", () => {
     const element = asElement(
       AspectRatio({
         asChild: true,

--- a/tests/jsdom/block.test.tsx
+++ b/tests/jsdom/block.test.tsx
@@ -12,7 +12,7 @@ function asElement(value: unknown): ElementLike {
 }
 
 describe("Block", () => {
-  it("should renders a canonical wrapper with CSS-driven layout props", () => {
+  it("should render a canonical wrapper with CSS-driven layout props", () => {
     const element = asElement(
       Block({
         maxWidth: "md",
@@ -29,7 +29,7 @@ describe("Block", () => {
     expect(element.props.style).toBeUndefined();
   });
 
-  it("should supports responsive layout props and asChild composition", () => {
+  it("should support responsive layout props and asChild composition", () => {
     const responsive = asElement(
       Block({
         direction: { base: "column", lg: "row" },

--- a/tests/jsdom/core-presets.test.tsx
+++ b/tests/jsdom/core-presets.test.tsx
@@ -12,7 +12,7 @@ function asElement(value: unknown): ElementLike {
 }
 
 describe("semantic core presets", () => {
-  it("should renders Header as a thin sticky Block preset", () => {
+  it("should render Header as a thin sticky Block preset", () => {
     const header = asElement(Header({ sticky: true, class: "header-custom", children: "nav" }));
 
     expect(header.type).toBe(Block);
@@ -25,7 +25,7 @@ describe("semantic core presets", () => {
     expect(header.props.class).toBe("header-custom");
   });
 
-  it("should renders Main and Sidebar with stable semantic slots", () => {
+  it("should render Main and Sidebar with stable semantic slots", () => {
     const sidebar = asElement(Sidebar({ children: "nav", class: "sidebar-custom" }));
     const main = asElement(Main({ children: "main", class: "main-custom" }));
 

--- a/tests/jsdom/navbar-chrome.test.tsx
+++ b/tests/jsdom/navbar-chrome.test.tsx
@@ -32,7 +32,7 @@ describe("navbar and sidebar chrome contracts", () => {
     resetTestRoutes();
   });
 
-  it("should renders the navbar and sidebar chrome with stable slots", async () => {
+  it("should render the navbar and sidebar chrome with stable slots", async () => {
     testRoute("/docs", () => (
       <>
         <Navbar aria-label="Docs navigation" id="docs-navbar">
@@ -84,7 +84,7 @@ describe("navbar and sidebar chrome contracts", () => {
     expect(container?.querySelector("#page")?.textContent).toBe("Docs");
   });
 
-  it("should renders responsive navbar and nav dropdown slots", async () => {
+  it("should render responsive navbar and nav dropdown slots", async () => {
     testRoute("/docs", () => (
       <Navbar aria-label="Responsive docs navigation" collapseAt="md" id="responsive-navbar">
         <NavBrand as="a" href="/">

--- a/tests/jsdom/navbar-link.test.tsx
+++ b/tests/jsdom/navbar-link.test.tsx
@@ -58,7 +58,7 @@ describe("navbar link jsdom regression", () => {
     resetTestRoutes();
   });
 
-  it("should marks the exact current route active", async () => {
+  it("should mark the exact current route active", async () => {
     window.history.replaceState({}, "", "/docs");
     registerNavRoutes();
 
@@ -80,7 +80,7 @@ describe("navbar link jsdom regression", () => {
     expect(childLink?.getAttribute("data-active")).toBeNull();
   });
 
-  it("should supports router Link as a NavBrand child", async () => {
+  it("should support router Link as a NavBrand child", async () => {
     window.history.replaceState({}, "", "/docs");
     testRoute("/", () => <div id="page">Home page</div>);
     testRoute("/docs", () => (
@@ -120,7 +120,7 @@ describe("navbar link jsdom regression", () => {
     expect(container?.querySelector("#page")?.textContent).toBe("Home page");
   });
 
-  it("should keeps parent NavLink active on child routes by default", async () => {
+  it("should keep parent NavLink active on child routes by default", async () => {
     window.history.replaceState({}, "", "/docs/getting-started");
     registerNavRoutes();
 
@@ -142,7 +142,7 @@ describe("navbar link jsdom regression", () => {
     expect(childLink?.getAttribute("data-active")).toBe("true");
   });
 
-  it("should supports exact and prefix matching in the same nav", async () => {
+  it("should support exact and prefix matching in the same nav", async () => {
     window.history.replaceState({}, "", "/docs/components");
     registerNavRoutes();
 
@@ -161,7 +161,7 @@ describe("navbar link jsdom regression", () => {
     expect(componentsLink?.getAttribute("data-active")).toBe("true");
   });
 
-  it("should preserves custom click handlers before client-side navigation", async () => {
+  it("should preserve custom click handlers before client-side navigation", async () => {
     let clicks = 0;
 
     window.history.replaceState({}, "", "/");
@@ -202,7 +202,7 @@ describe("navbar link jsdom regression", () => {
     expect(container?.querySelector("#page")?.textContent).toBe("Docs page");
   });
 
-  it("should does not intercept modified clicks or explicit targets", async () => {
+  it("should not intercept modified clicks or explicit targets", async () => {
     window.history.replaceState({}, "", "/");
     testRoute("/", () => (
       <nav aria-label="Primary">
@@ -246,7 +246,7 @@ describe("navbar link jsdom regression", () => {
     expect(window.location.pathname).toBe("/");
   });
 
-  it("should leaves external links to native browser navigation", async () => {
+  it("should leave external links to native browser navigation", async () => {
     let wasDefaultPreventedByNavLink: boolean | undefined;
 
     window.history.replaceState({}, "", "/");
@@ -283,7 +283,7 @@ describe("navbar link jsdom regression", () => {
     expect(window.location.pathname).toBe("/");
   });
 
-  it("should leaves same-page hash links to native browser navigation", async () => {
+  it("should leave same-page hash links to native browser navigation", async () => {
     let wasDefaultPreventedByNavLink: boolean | undefined;
 
     window.history.replaceState({}, "", "/docs");
@@ -318,7 +318,7 @@ describe("navbar link jsdom regression", () => {
     expect(window.location.pathname).toBe("/docs");
   });
 
-  it("should leaves same-origin downloads to native browser navigation", async () => {
+  it("should leave same-origin downloads to native browser navigation", async () => {
     let wasDefaultPreventedByNavLink: boolean | undefined;
 
     window.history.replaceState({}, "", "/");
@@ -358,7 +358,7 @@ describe("navbar link jsdom regression", () => {
     expect(window.location.pathname).toBe("/");
   });
 
-  it("should preserves route behavior through DropdownItem asChild with NavLink", async () => {
+  it("should preserve route behavior through DropdownItem asChild with NavLink", async () => {
     window.history.replaceState({}, "", "/");
     testRoute("/", () => (
       <nav aria-label="Primary">
@@ -407,7 +407,7 @@ describe("navbar link jsdom regression", () => {
     expect(container?.querySelector("#page")?.textContent).toBe("Docs page");
   });
 
-  it("should keeps DropdownItem asChild NavLink native behavior for non-SPA link clicks", async () => {
+  it("should keep DropdownItem asChild NavLink native behavior for non-SPA link clicks", async () => {
     let externalDefaultPrevented: boolean | undefined;
     let modifiedWasNotCancelled: boolean | undefined;
 
@@ -468,7 +468,7 @@ describe("navbar link jsdom regression", () => {
     expect(window.location.pathname).toBe("/");
   });
 
-  it("should keeps route matching props off plain NavItem anchors", () => {
+  it("should keep route matching props off plain NavItem anchors", () => {
     const item = NavItem({
       href: "/docs",
       children: "Docs",
@@ -479,7 +479,7 @@ describe("navbar link jsdom regression", () => {
     expect(item.props.href).toBe("/docs");
   });
 
-  it("should passes NavItem layout props through asChild without leaking route-only props", () => {
+  it("should pass NavItem layout props through asChild without leaking route-only props", () => {
     const item = NavItem({
       asChild: true,
       children: {

--- a/tests/jsdom/saas-patterns.test.tsx
+++ b/tests/jsdom/saas-patterns.test.tsx
@@ -5,7 +5,7 @@ import { Block, EmptyState } from "../../src/core";
 import { Card } from "../../src/surfaces";
 
 describe("product SaaS composition patterns", () => {
-  it("should builds dashboard content while leaving app layout in userland", () => {
+  it("should build dashboard content while leaving app layout in userland", () => {
     const page = (
       <div class="ops-app-layout">
         <aside class="ops-app-layout-nav">
@@ -46,7 +46,7 @@ describe("product SaaS composition patterns", () => {
     expect(page).toBeTruthy();
   });
 
-  it("should builds settings and empty states from reusable pattern primitives", () => {
+  it("should build settings and empty states from reusable pattern primitives", () => {
     const settings = Block({
       gap: "xl",
       children: [

--- a/tests/jsdom/scaffold-slot-contract.test.tsx
+++ b/tests/jsdom/scaffold-slot-contract.test.tsx
@@ -31,7 +31,7 @@ describe("empty state slot contract", () => {
     resetTestRoutes();
   });
 
-  it("should emits canonical data-slot hooks for common composition", async () => {
+  it("should emit canonical data-slot hooks for common composition", async () => {
     testRoute("/example", () => (
       <div class="dashboard-page">
         <EmptyState

--- a/tests/jsdom/spinner.test.tsx
+++ b/tests/jsdom/spinner.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { Spinner } from "../../src/surfaces";
 
 describe("spinner wrapper", () => {
-  it("should renders deterministic spinner element trees", () => {
+  it("should render deterministic spinner element trees", () => {
     const spinnerOne = Spinner({ label: "Syncing" }) as {
       type: unknown;
       props: Record<string, unknown>;

--- a/tests/jsdom/theme-route-persistence.test.tsx
+++ b/tests/jsdom/theme-route-persistence.test.tsx
@@ -85,7 +85,7 @@ describe("theme route persistence", () => {
     restoreLocalStorage = undefined;
   });
 
-  it("should preserves the active theme across route navigation", async () => {
+  it("should preserve the active theme across route navigation", async () => {
     const AppLayout = ({ children }: { children?: unknown }) => (
       <ThemeScope defaultTheme="light">
         <header>
@@ -218,7 +218,7 @@ describe("theme route persistence", () => {
     expect(getVisibleIcon()?.getAttribute("data-icon")).toBe("moon");
   });
 
-  it("should mounts theme controls without render-time state errors", async () => {
+  it("should mount theme controls without render-time state errors", async () => {
     const AppLayout = () => (
       <ThemeScope defaultTheme="light">
         <header>

--- a/tests/unit/alias-contract.test.ts
+++ b/tests/unit/alias-contract.test.ts
@@ -113,7 +113,7 @@ describe("daisy-like class aliases", () => {
     }
   }
 
-  it("should documents raw class authoring examples in the alias contract", () => {
+  it("should document raw class authoring examples in the alias contract", () => {
     const examples = [
       '<button class="btn btn-primary btn-sm">Save</button>',
       '<section class="card"><h3>Usage</h3><div>Current workspace metrics.</div></section>',

--- a/tests/unit/block-first-components.test.ts
+++ b/tests/unit/block-first-components.test.ts
@@ -59,7 +59,7 @@ function findElementBySlot(value: unknown, slot: string): ElementLike | undefine
 }
 
 describe("block-first components", () => {
-  it("should exposes the stable core surface", () => {
+  it("should expose the stable core surface", () => {
     for (const component of [
       Block,
       Brand,
@@ -95,7 +95,7 @@ describe("block-first components", () => {
     }
   });
 
-  it("should maps recipe-style Block props to generated layout classes", () => {
+  it("should map recipe-style Block props to generated layout classes", () => {
     const block = asElement(
       Block({
         as: "main",
@@ -122,7 +122,7 @@ describe("block-first components", () => {
     expect(String(block.props.class)).toContain("ak-style-");
   });
 
-  it("should builds semantic wrappers on Block", () => {
+  it("should build semantic wrappers on Block", () => {
     const container = asElement(Container({ children: "container" }));
     const brandRoot = asElement(
       Brand({ children: [BrandMark({ children: "D" }), BrandLabel({ children: "Destroyer" })] }),
@@ -192,7 +192,7 @@ describe("block-first components", () => {
     expect(brand.props["data-slot"]).toBe("nav-brand");
   });
 
-  it("should exposes common composition components without recipe-only layouts", () => {
+  it("should expose common composition components without recipe-only layouts", () => {
     expect(Page({ children: "page" })).toBeTruthy();
     expect(
       PageHeader({ title: "Projects", description: "Manage work.", actions: "actions" }),
@@ -202,7 +202,7 @@ describe("block-first components", () => {
     expect(Text({ tone: "muted", size: "sm", children: "Copy" })).toBeTruthy();
   });
 
-  it("should keeps visual display primitives with one separator name", () => {
+  it("should keep visual display primitives with one separator name", () => {
     expect(Badge({ children: "new", variant: "secondary" })).toBeTruthy();
     expect(Skeleton({})).toBeTruthy();
     expect(Separator({ orientation: "vertical" })).toBeTruthy();

--- a/tests/unit/component-coverage.test.ts
+++ b/tests/unit/component-coverage.test.ts
@@ -29,7 +29,7 @@ function assertFileExists(relativePath: string, message: string): void {
 }
 
 describe("component coverage matrix", () => {
-  it("should keeps every public non-chart component represented in the themes catalog", () => {
+  it("should keep every public non-chart component represented in the themes catalog", () => {
     const namespace = components as Record<string, unknown>;
 
     for (const component of THEME_COMPONENTS) {
@@ -39,7 +39,7 @@ describe("component coverage matrix", () => {
     expect(namespace[EXCLUDED_CHART_COMPONENT]).toBeUndefined();
   });
 
-  it("should keeps every public non-chart component represented by a package subpath", () => {
+  it("should keep every public non-chart component represented by a package subpath", () => {
     expect(THEME_COMPONENT_SUBPATHS).not.toContain("chart");
     expect(THEME_COMPONENT_SUBPATHS).not.toContain("charts");
 
@@ -49,7 +49,7 @@ describe("component coverage matrix", () => {
     }
   });
 
-  it("should keeps direct tests and composition benches attached to the public catalog", () => {
+  it("should keep direct tests and composition benches attached to the public catalog", () => {
     for (const testFile of DIRECT_TESTS) {
       assertFileExists(testFile, `missing direct test file ${testFile}`);
     }

--- a/tests/unit/components-entrypoint.test.ts
+++ b/tests/unit/components-entrypoint.test.ts
@@ -91,7 +91,7 @@ function asElement(value: unknown): ElementLike {
 }
 
 describe("components entrypoint", () => {
-  it("should exposes styled components and behavior primitives from one catalog", () => {
+  it("should expose styled components and behavior primitives from one catalog", () => {
     for (const component of [
       Alert,
       Brand,
@@ -137,7 +137,7 @@ describe("components entrypoint", () => {
     }
   });
 
-  it("should renders new catalog-only anatomy with stable slots", () => {
+  it("should render new catalog-only anatomy with stable slots", () => {
     expect(asElement(AlertTitle({ children: "Heads up" })).props["data-slot"]).toBe("alert-title");
     expect(asElement(AlertDescription({ children: "Details" })).props["data-slot"]).toBe(
       "alert-description",

--- a/tests/unit/docs-surface.test.ts
+++ b/tests/unit/docs-surface.test.ts
@@ -20,7 +20,7 @@ function sourceFiles(directory: string): string[] {
 }
 
 describe("docs surface", () => {
-  it("should documents the component catalog package surface", () => {
+  it("should document the component catalog package surface", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
@@ -34,7 +34,7 @@ describe("docs surface", () => {
     expect(pkg.exports?.["./overlays"]).toBeUndefined();
   });
 
-  it("should keeps docs aligned with the new component catalog imports", () => {
+  it("should keep docs aligned with the new component catalog imports", () => {
     const docs = [
       readFileSync(README, "utf-8"),
       readFileSync(THEMES_DOC, "utf-8"),
@@ -55,7 +55,7 @@ describe("docs surface", () => {
     expect(docs).not.toContain("@askrjs/themes/overlays");
   });
 
-  it("should documents catalog coverage without moving charts into themes", () => {
+  it("should document catalog coverage without moving charts into themes", () => {
     const readme = readFileSync(README, "utf-8");
     const themingDoc = readFileSync(THEMING_DOC, "utf-8");
 
@@ -66,7 +66,7 @@ describe("docs surface", () => {
     expect(EXCLUDED_CHART_COMPONENT).toBe("Chart");
   });
 
-  it("should keeps external project attribution in acknowledgements, not source or tests", () => {
+  it("should keep external project attribution in acknowledgements, not source or tests", () => {
     const acknowledgements = readFileSync(ACKNOWLEDGEMENTS, "utf-8");
     const externalProjectNames = [...acknowledgements.matchAll(/^- \[([^\]]+)\]/gmu)].map(
       ([, name]) => name,

--- a/tests/unit/icons.test.ts
+++ b/tests/unit/icons.test.ts
@@ -11,13 +11,13 @@ import {
 const TOKENS_FILE = DEFAULT_THEME_TOKENS_FILE;
 
 describe("icon theme contract", () => {
-  it("should ships the same icon baseline in default and template themes", () => {
+  it("should ship the same icon baseline in default and template themes", () => {
     const defaultCss = readFileSync(DEFAULT_ICON_CSS, "utf-8");
     const templateCss = readFileSync(TEMPLATE_ICON_CSS, "utf-8");
     expect(templateCss).toBe(defaultCss);
   });
 
-  it("should documents the icon public hooks", () => {
+  it("should document the icon public hooks", () => {
     const docs = readFileSync(THEMING_FILE, "utf-8");
     expect(docs).toContain("`@askrjs/ui` owns the canonical icon hooks");
     expect(docs).toContain('`data-slot="icon"`');
@@ -26,7 +26,7 @@ describe("icon theme contract", () => {
     expect(docs).toContain("--ak-icon-size-sm");
   });
 
-  it("should defines icon size and stroke tokens", () => {
+  it("should define icon size and stroke tokens", () => {
     const tokens = readFileSync(TOKENS_FILE, "utf-8");
     expect(tokens).toContain("--ak-icon-size-sm");
     expect(tokens).toContain("--ak-icon-size-md");

--- a/tests/unit/jsx-helpers.test.ts
+++ b/tests/unit/jsx-helpers.test.ts
@@ -19,7 +19,7 @@ const AnonymousWidget = function (props: WidgetProps): JSX.Element {
 Object.defineProperty(AnonymousWidget, "name", { value: "" });
 
 describe("JSX serialization helpers", () => {
-  it("should serializes arrays, nested trees, and stable prop filters", () => {
+  it("should serialize arrays, nested trees, and stable prop filters", () => {
     const value = jsxs("section", {
       "data-slot": "root",
       children: [
@@ -56,7 +56,7 @@ describe("JSX serialization helpers", () => {
     ).toBe("div[data-state:idle]()");
   });
 
-  it("should returns stable fallbacks for unsupported values", () => {
+  it("should return stable fallbacks for unsupported values", () => {
     expect(serializeForId(undefined)).toBe("");
     expect(serializeForId(null)).toBe("");
     expect(serializeForId(false)).toBe("");

--- a/tests/unit/layout-helpers.test.ts
+++ b/tests/unit/layout-helpers.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../src/components/_internal/style";
 
 describe("block layout helpers", () => {
-  it("should serializes layout declarations with user overrides", () => {
+  it("should serialize layout declarations with user overrides", () => {
     expect(
       mergeLayoutStyles(
         {
@@ -27,7 +27,7 @@ describe("block layout helpers", () => {
     ).toBe("--ak-gap-base:var(--ak-space-lg);--ak-px-base:var(--ak-layout-page-gutter);color:red");
   });
 
-  it("should splits block layout props from passthrough props", () => {
+  it("should split block layout props from passthrough props", () => {
     const { blockProps, rest } = splitBlockLayoutProps({
       paddingX: "page",
       maxWidth: "page",
@@ -44,7 +44,7 @@ describe("block layout helpers", () => {
     expect(rest).toEqual({ class: "chrome", title: "Layout chrome" });
   });
 
-  it("should maps block layout props to responsive css custom properties", () => {
+  it("should map block layout props to responsive css custom properties", () => {
     const styles: Record<string, string | number> = {};
 
     applyBlockLayoutStyles(styles, {
@@ -98,7 +98,7 @@ describe("block layout helpers", () => {
 });
 
 describe("style helpers", () => {
-  it("should appends css custom properties to string and object styles", () => {
+  it("should append css custom properties to string and object styles", () => {
     expect(mergeCssVar("color:red", "--ak-test", "1rem")).toBe("color:red;--ak-test:1rem");
     expect(mergeCssVar({ backgroundColor: "red", opacity: 0.5 }, "--ak-test", "1rem")).toBe(
       "background-color:red;opacity:0.5;--ak-test:1rem",

--- a/tests/unit/merge-props.test.ts
+++ b/tests/unit/merge-props.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import { mergeProps } from "../../src/components/_internal/merge-props";
 
 describe("mergeProps", () => {
-  it("should composes refs without dropping either target", () => {
+  it("should compose refs without dropping either target", () => {
     const injectedRef = { current: null as HTMLDivElement | null };
     let baseRefValue: HTMLDivElement | null = null;
 
@@ -23,7 +23,7 @@ describe("mergeProps", () => {
     expect(baseRefValue).toBe(node);
   });
 
-  it("should runs injected handlers first and respects preventDefault", () => {
+  it("should run injected handlers first and respect preventDefault", () => {
     const calls: string[] = [];
     const event = {
       defaultPrevented: false,
@@ -51,7 +51,7 @@ describe("mergeProps", () => {
     expect(calls).toEqual(["injected"]);
   });
 
-  it("should composes class names instead of dropping defaults", () => {
+  it("should compose class names instead of dropping defaults", () => {
     const merged = mergeProps(
       {
         class: "my-badge",

--- a/tests/unit/navigation-contracts.test.ts
+++ b/tests/unit/navigation-contracts.test.ts
@@ -39,7 +39,7 @@ function findElementBySlot(value: unknown, slot: string): ElementLike | undefine
 }
 
 describe("navigation contracts", () => {
-  it("should renders block-first nav primitives with canonical slots", () => {
+  it("should render block-first nav primitives with canonical slots", () => {
     const tabs = asElement(Tabs({ children: "tabs" }));
     const tab = asElement(Tab({ href: "/settings/profile", active: true, children: "Profile" }));
     const tabChild = asElement(tab.props.children);

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -136,7 +136,7 @@ function hasModuleBinding(bindings: ReadonlySet<string>, name: string): boolean 
 }
 
 describe("package surface", () => {
-  it("should exposes the styled component catalog from the aggregate entrypoint", () => {
+  it("should expose the styled component catalog from the aggregate entrypoint", () => {
     const namespace = components as Record<string, unknown>;
 
     for (const component of THEME_COMPONENTS) {
@@ -149,7 +149,7 @@ describe("package surface", () => {
     expect(typeof ThemeToggle).toBe("function");
   });
 
-  it("should publishes component subpaths and keeps charts out of themes", () => {
+  it("should publish component subpaths and keep charts out of themes", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
@@ -212,7 +212,7 @@ describe("package surface", () => {
     }
   });
 
-  it("should keeps accessibility contracts out of app-facing barrels", () => {
+  it("should keep accessibility contracts out of app-facing barrels", () => {
     const barrels = [
       "src/components.ts",
       "src/theme.ts",
@@ -233,7 +233,7 @@ describe("package surface", () => {
     }
   });
 
-  it("should keeps reported catalog wrappers sourced from the built catalog artifacts", () => {
+  it("should keep reported catalog wrappers sourced from the built catalog artifacts", () => {
     ensureComponentDistArtifacts();
 
     for (const artifact of COMPONENT_DIST_ARTIFACTS) {
@@ -255,7 +255,7 @@ describe("package surface", () => {
     }
   }, 30_000);
 
-  it("should keeps default CSS package exports pointed at real files", () => {
+  it("should keep default CSS package exports pointed at real files", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
@@ -278,7 +278,7 @@ describe("package surface", () => {
     }
   });
 
-  it("should keeps preset CSS package exports pointed at real files", () => {
+  it("should keep preset CSS package exports pointed at real files", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
@@ -293,7 +293,7 @@ describe("package surface", () => {
     ).toBe(true);
   });
 
-  it("should keeps recipe layout imports out of the shipped theme CSS", () => {
+  it("should keep recipe layout imports out of the shipped theme CSS", () => {
     const defaultIndex = readFileSync(DEFAULT_INDEX, "utf-8");
     const templateIndex = readFileSync(TEMPLATE_INDEX, "utf-8");
 

--- a/tests/unit/presets.test.ts
+++ b/tests/unit/presets.test.ts
@@ -57,7 +57,7 @@ function extractDefinedTokens(css: string): Set<string> {
 }
 
 describe("cat theme presets", () => {
-  it("should publishes the combined cat preset stylesheet", () => {
+  it("should publish the combined cat preset stylesheet", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
       exports?: Record<string, unknown>;
     };
@@ -69,7 +69,7 @@ describe("cat theme presets", () => {
     expect(existsSync(PRESETS_INDEX_FILE)).toBe(true);
   });
 
-  it("should collects every cat preset in the combined stylesheet", () => {
+  it("should collect every cat preset in the combined stylesheet", () => {
     const css = readFileSync(PRESETS_INDEX_FILE, "utf-8");
 
     for (const preset of PRESET_NAMES) {

--- a/tests/unit/responsive-theme-contract.test.ts
+++ b/tests/unit/responsive-theme-contract.test.ts
@@ -75,7 +75,7 @@ describe("responsive theme contract", () => {
   const normalizedDefaultLayout = defaultLayout.replace(/'/g, '"');
   const normalizedDefaultNavbar = defaultNavbar.replace(/'/g, '"');
 
-  it("should keeps the default theme Block layout contract in place", () => {
+  it("should keep the default theme Block layout contract in place", () => {
     for (const forbiddenImport of FORBIDDEN_LEGACY_IMPORTS) {
       expect(defaultIndex).not.toContain(forbiddenImport);
     }
@@ -89,7 +89,7 @@ describe("responsive theme contract", () => {
     }
   });
 
-  it("should keeps the generated theme template aligned with the default layout contract", () => {
+  it("should keep the generated theme template aligned with the default layout contract", () => {
     for (const forbiddenImport of FORBIDDEN_LEGACY_IMPORTS) {
       expect(templateIndex).not.toContain(forbiddenImport);
     }
@@ -101,7 +101,7 @@ describe("responsive theme contract", () => {
     expect(templateLayout).toBe(defaultLayout);
   });
 
-  it("should keeps the Navbar responsive contract in the default theme", () => {
+  it("should keep the Navbar responsive contract in the default theme", () => {
     for (const snippet of REQUIRED_NAVBAR_SNIPPETS) {
       expect(normalizedDefaultNavbar).toContain(snippet);
     }
@@ -116,11 +116,11 @@ describe("responsive theme contract", () => {
     expect(xlBlock).toMatch(/padding-block:\s*var\(\s*--ak-py-xl/);
   });
 
-  it("should keeps the generated theme template aligned with the default Navbar contract", () => {
+  it("should keep the generated theme template aligned with the default Navbar contract", () => {
     expect(templateNavbar).toBe(defaultNavbar);
   });
 
-  it("should applies static utilities after the Block layout engine", () => {
+  it("should apply static utilities after the Block layout engine", () => {
     expect(defaultIndex.indexOf("./styles/layout/layout.css")).toBeLessThan(
       defaultIndex.indexOf("./styles/base/utilities.css"),
     );
@@ -129,7 +129,7 @@ describe("responsive theme contract", () => {
     );
   });
 
-  it("should documents responsive theming guidance", () => {
+  it("should document responsive theming guidance", () => {
     const requiredDocs = [
       "Build mobile first.",
       "`base`, `sm`, `md`, `lg`, and `xl`",

--- a/tests/unit/selectors.test.ts
+++ b/tests/unit/selectors.test.ts
@@ -469,7 +469,7 @@ describe("legacy layout utility cleanup", () => {
 });
 
 describe("tokens.css selector contract", () => {
-  it("should uses only :root and [data-theme] selectors", () => {
+  it("should use only :root and [data-theme] selectors", () => {
     const css = readFileSync(TOKENS_FILE, "utf-8");
     const selectors = extractSelectors(css);
 

--- a/tests/unit/slot-coverage.test.ts
+++ b/tests/unit/slot-coverage.test.ts
@@ -204,12 +204,12 @@ describe("slot coverage", () => {
   const themeSlots = extractThemeSlots();
   const themeComponentSlots = extractSourceSlots(THEME_SOURCE_COMPONENTS_DIR);
 
-  it("should finds slots in askr-ui and the default theme", () => {
+  it("should find slots in askr-ui and the default theme", () => {
     expect(uiSlots.size).toBeGreaterThan(0);
     expect(themeSlots.size).toBeGreaterThan(0);
   });
 
-  it("should covers every askr-ui slot in the default theme CSS", () => {
+  it("should cover every askr-ui slot in the default theme CSS", () => {
     const uncovered = [...uiSlots]
       .filter((slot) => !themeSlots.has(slot) && !ALLOWED_UNCOVERED_UI_SLOTS.has(slot))
       .sort();
@@ -220,7 +220,7 @@ describe("slot coverage", () => {
     ).toEqual([]);
   });
 
-  it("should does not leave stale theme-only slots", () => {
+  it("should not leave stale theme-only slots", () => {
     const themeOnly = [...themeSlots]
       .filter(
         (slot) =>

--- a/tests/unit/theme-aliases.test.ts
+++ b/tests/unit/theme-aliases.test.ts
@@ -21,7 +21,7 @@ function asElement(value: unknown): ElementLike {
 }
 
 describe("theme alias classes", () => {
-  it("should emits the familiar surface aliases by default", () => {
+  it("should emit the familiar surface aliases by default", () => {
     expect(asElement(Card({ children: "body" })).props.class).toBe("card");
     expect(asElement(Card({ children: "body", variant: "raised" })).props.class).toBe(
       "card card-raised",
@@ -37,7 +37,7 @@ describe("theme alias classes", () => {
     ).toBe("alert alert-info alert-dismissible");
   });
 
-  it("should emits the familiar control aliases by default", () => {
+  it("should emit the familiar control aliases by default", () => {
     expect(asElement(ButtonGroup({ children: "group" })).props.class).toBe("btn-group");
     expect(asElement(ButtonGroup({ children: "group", orientation: "vertical" })).props.class).toBe(
       "btn-group btn-group-vertical",

--- a/tests/unit/theme-toggle.test.ts
+++ b/tests/unit/theme-toggle.test.ts
@@ -13,7 +13,7 @@ describe("ThemeToggle", () => {
     expect(source).not.toContain("__askrStaticChildSlots");
   });
 
-  it("should falls back to the next theme icon when the current choice is system", () => {
+  it("should fall back to the next theme icon when the current choice is system", () => {
     expect(
       resolveThemeToggleIcon("system", "light", {
         lightIcon: "sun",
@@ -22,7 +22,7 @@ describe("ThemeToggle", () => {
     ).toBe("sun");
   });
 
-  it("should prefers the explicit current-theme icon when available", () => {
+  it("should prefer the explicit current-theme icon when available", () => {
     expect(
       resolveThemeToggleIcon("dark", "light", {
         lightIcon: "sun",
@@ -32,7 +32,7 @@ describe("ThemeToggle", () => {
     ).toBe("moon");
   });
 
-  it("should prefers the explicit system icon when available", () => {
+  it("should prefer the explicit system icon when available", () => {
     expect(
       resolveThemeToggleIcon("system", "light", {
         lightIcon: "sun",
@@ -42,7 +42,7 @@ describe("ThemeToggle", () => {
     ).toBe("laptop");
   });
 
-  it("should falls back from a missing current icon to the next theme icon", () => {
+  it("should fall back from a missing current icon to the next theme icon", () => {
     expect(
       resolveThemeToggleIcon("light", "dark", {
         darkIcon: "moon",
@@ -60,7 +60,7 @@ describe("ThemeToggle", () => {
     ).toBeUndefined();
   });
 
-  it("should falls back from a custom current theme to a standard next-theme icon", () => {
+  it("should fall back from a custom current theme to a standard next-theme icon", () => {
     expect(
       resolveThemeToggleIcon("neon", "dark", {
         lightIcon: "sun",

--- a/tests/unit/visual-quality-contract.test.ts
+++ b/tests/unit/visual-quality-contract.test.ts
@@ -40,7 +40,7 @@ describe("visual quality contract", () => {
   const dropdownCss = read(DROPDOWN_CSS_FILE);
   const tooltipCss = read(TOOLTIP_CSS_FILE);
 
-  it("should keeps the manual audit page broad enough for polish work", () => {
+  it("should keep the manual audit page broad enough for polish work", () => {
     const requiredAuditCopy = [
       "Component audit, one family at a time.",
       "Quality checklist",
@@ -63,7 +63,7 @@ describe("visual quality contract", () => {
     expect(visualCheck).toContain('data-theme="dark"');
   });
 
-  it("should documents the visual audit standard and responsive widths", () => {
+  it("should document the visual audit standard and responsive widths", () => {
     const requiredDocs = [
       "Visual Quality Standard",
       "visual-check.html",
@@ -85,7 +85,7 @@ describe("visual quality contract", () => {
     expect(docsOverview).toContain("[Theming](./theming.md)");
   });
 
-  it("should documents that default theme CSS and templates move together", () => {
+  it("should document that default theme CSS and templates move together", () => {
     const requiredTemplateSync = [
       "src/themes/default/styles",
       "templates/theme/styles",


### PR DESCRIPTION
Normalize 113 test titles across unit, jsdom, and browser suites to the project-standard should + base-verb form without changing behavior.\n\nLocal verification:\n- npx vp fmt .\n- npm ci\n- npm audit --audit-level=moderate\n- npm run check