### PR TITLE
chore: release 0.0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",


### PR DESCRIPTION
Publish the latest merged main work as 0.0.24.

Verification:
- npx askr upgrade
- npx vp fmt .
- npm ci
- npm audit --audit-level=moderate
- npm run check