### PR TITLE
Preserve routed links when navigation handlers are present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",

--- a/src/components/nav/nav.tsx
+++ b/src/components/nav/nav.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "@askrjs/askr/jsx-runtime";
 import { Slot } from "@askrjs/askr/foundations";
-import { currentRoute, Link, navigate } from "@askrjs/askr/router";
+import { currentRoute, Link } from "@askrjs/askr/router";
 import { Block } from "../block";
 import { classes } from "../_internal/classes";
 import { mergeProps } from "../_internal/merge-props";
@@ -54,25 +54,6 @@ function isActiveNavLink(
   }
 
   return currentPathname === targetPathname || currentPathname.startsWith(`${targetPathname}/`);
-}
-
-function shouldHandleClientNavigation(
-  event: MouseEvent,
-  target: string | undefined,
-  targetPathname: string | null,
-): boolean {
-  if (targetPathname === null || target) {
-    return false;
-  }
-
-  return (
-    !event.defaultPrevented &&
-    (event.button ?? 0) === 0 &&
-    !event.altKey &&
-    !event.ctrlKey &&
-    !event.metaKey &&
-    !event.shiftKey
-  );
 }
 
 function renderNavSet(
@@ -145,27 +126,14 @@ function renderRoutedLink(
     : {
         "data-active": undefined,
       };
-  const rendersRouterLink =
-    targetPathname !== null &&
-    !target &&
-    !hasDownload &&
-    typeof onClick !== "function" &&
-    typeof onPress !== "function";
+  const rendersRouterLink = targetPathname !== null && !target && !hasDownload;
   const childProps: NavLinkProps = to
-    ? ({ ...childRest, to, target } as NavLinkProps)
-    : ({ ...childRest, href, target } as NavLinkProps);
+    ? ({ ...childRest, to, target, onPress, onClick } as NavLinkProps)
+    : ({ ...childRest, href, target, onPress, onClick } as NavLinkProps);
   const handleClick = (event: MouseEvent) => {
     onPress?.(event);
     if (event.defaultPrevented) return;
     onClick?.(event);
-    if (hasDownload) return;
-
-    if (!shouldHandleClientNavigation(event, target, targetPathname)) {
-      return;
-    }
-
-    event.preventDefault();
-    navigate(href);
   };
 
   return (

--- a/tests/jsdom/navbar-link.test.tsx
+++ b/tests/jsdom/navbar-link.test.tsx
@@ -5,6 +5,7 @@ import { cleanupApp, createSPA } from "@askrjs/askr/boot";
 import { Link } from "@askrjs/askr/router";
 
 import { Block, NavBrand, NavItem, NavLink, Navbar } from "../../src/core";
+import { Pill, Tab } from "../../src/navs";
 import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "../../src/overlays";
 
 type ElementLike = {
@@ -200,6 +201,79 @@ describe("navbar link jsdom regression", () => {
     expect(clicks).toBe(1);
     expect(window.location.pathname).toBe("/docs");
     expect(container?.querySelector("#page")?.textContent).toBe("Docs page");
+  });
+
+  it("should preserve the registry base path when a NavLink has a click handler", async () => {
+    let clicks = 0;
+
+    window.history.replaceState({}, "", "/website/");
+    testRoute("/", () => (
+      <NavLink href="/docs" onClick={() => (clicks += 1)}>
+        Docs
+      </NavLink>
+    ));
+    testRoute("/docs", () => <div id="page">Docs page</div>);
+
+    await createSPA({ root: container!, registry: createTestRegistry({ basePath: "/website" }) });
+    await settle();
+
+    const docsLink = container?.querySelector("a") as HTMLAnchorElement | null;
+    expect(docsLink?.getAttribute("href")).toBe("/website/docs");
+
+    docsLink?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+    );
+    await settle();
+
+    expect(clicks).toBe(1);
+    expect(window.location.pathname).toBe("/website/docs");
+    expect(container?.querySelector("#page")?.textContent).toBe("Docs page");
+  });
+
+  it("should preserve routed link behavior for onPress, Tab, and Pill", async () => {
+    let presses = 0;
+
+    window.history.replaceState({}, "", "/website/");
+    testRoute("/", () => (
+      <>
+        <NavLink href="/nav" onPress={() => (presses += 1)}>
+          Nav
+        </NavLink>
+        <Tab href="/tab" onClick={(event) => event.preventDefault()}>
+          Tab
+        </Tab>
+        <Pill href="/pill" onClick={() => undefined}>
+          Pill
+        </Pill>
+      </>
+    ));
+    testRoute("/nav", () => <div id="page">Nav page</div>);
+    testRoute("/tab", () => <div id="page">Tab page</div>);
+    testRoute("/pill", () => <div id="page">Pill page</div>);
+
+    await createSPA({ root: container!, registry: createTestRegistry({ basePath: "/website" }) });
+    await settle();
+
+    const links = Array.from(container!.querySelectorAll("a"));
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "/website/nav",
+      "/website/tab",
+      "/website/pill",
+    ]);
+
+    const tabClickWasNotCancelled = links[1]?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+    );
+    await settle();
+    expect(tabClickWasNotCancelled).toBe(false);
+    expect(window.location.pathname).toBe("/website/");
+
+    links[0]?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
+    );
+    await settle();
+    expect(presses).toBe(1);
+    expect(window.location.pathname).toBe("/website/nav");
   });
 
   it("should not intercept modified clicks or explicit targets", async () => {

--- a/tests/router-test-utils.ts
+++ b/tests/router-test-utils.ts
@@ -5,6 +5,7 @@ import {
   type RouteHandler,
   type RouteOptions,
   type RouteRegistry,
+  type RouteRegistryOptions,
 } from "@askrjs/askr/router";
 
 type TestRouteDefinition = {
@@ -38,7 +39,7 @@ export function testRoute(path: string, handler: RouteHandler, options?: RouteOp
   definitions.push({ path, handler, options, groups: [...groupStack] });
 }
 
-export function createTestRegistry(): RouteRegistry {
+export function createTestRegistry(options?: RouteRegistryOptions): RouteRegistry {
   const currentDefinitions = [...definitions];
   return createRouteRegistry(() => {
     for (const definition of currentDefinitions) {
@@ -52,5 +53,5 @@ export function createTestRegistry(): RouteRegistry {
       };
       define(0);
     }
-  });
+  }, options);
 }


### PR DESCRIPTION
## Summary
- keep internal `NavLink`, `Tab`, and `Pill` destinations on Askr `Link` when callbacks are supplied
- compose `onClick` and `onPress` without losing base paths or native modified-click behavior
- retain plain-anchor behavior for external, targeted, hash, and download links
- remove the unreachable manual-navigation fallback
- bump `@askrjs/themes` to `0.0.25`

Closes #60

## TDD
- regression first rendered `/docs` instead of `/website/docs`
- callback, cancellation, mounted href, and shared component regressions pass
- `npm run check` passes (including 564 unit and 183 browser tests, package and bundle verification)