### PR TITLE
fix: reject CSS comment delimiter injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",

--- a/src/components/_internal/style.ts
+++ b/src/components/_internal/style.ts
@@ -4,6 +4,7 @@ const cssPropertyNameCache = new Map<string, string>();
 const MAX_PROPERTY_CACHE = 256;
 
 const CSS_UNSAFE_RE = /[{}<>\\]/;
+const CSS_COMMENT_DELIMITER_RE = /\/\*|\*\//;
 const CSS_URI_SCHEME_RE = /(?:^|[\s(,])([a-z][a-z0-9+.-]*):/i;
 const CSS_FUNCTION_NAME_RE = /([a-z-][a-z0-9-]*)\s*\(/gi;
 const CSS_ALLOWED_FUNCTIONS = new Set([
@@ -57,7 +58,13 @@ function isSafeCssPropertyName(name: string): boolean {
 }
 
 function isSafeCssValue(value: string): boolean {
-  if (CSS_UNSAFE_RE.test(value) || CSS_URI_SCHEME_RE.test(value)) return false;
+  if (
+    CSS_UNSAFE_RE.test(value) ||
+    CSS_COMMENT_DELIMITER_RE.test(value) ||
+    CSS_URI_SCHEME_RE.test(value)
+  ) {
+    return false;
+  }
 
   for (const match of value.matchAll(CSS_FUNCTION_NAME_RE)) {
     if (!CSS_ALLOWED_FUNCTIONS.has(match[1]!.toLowerCase())) return false;

--- a/tests/jsdom/generated-style-ssr.test.tsx
+++ b/tests/jsdom/generated-style-ssr.test.tsx
@@ -16,6 +16,35 @@ function removeStyleRegistries(): void {
   }
 }
 
+function cssCommentInjectionCases(): string[] {
+  let state = 0x64c55a1;
+  const nextToken = (): string => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return (state >>> 0).toString(36);
+  };
+  const cases: string[] = [];
+
+  for (let index = 0; index < 24; index += 1) {
+    const prefix = nextToken();
+    const suffix = nextToken();
+    for (const delimiter of ["/*", "*/"]) {
+      cases.push(
+        `${delimiter}${suffix}`,
+        `${prefix}${delimiter}${suffix}`,
+        `${prefix}${delimiter}`,
+        `"${prefix}${delimiter}${suffix}"`,
+        `${prefix} ${delimiter} ${suffix}`,
+        `${prefix}${delimiter}${delimiter}${suffix}`,
+      );
+    }
+    cases.push(`${prefix}/*nested*/${suffix}`);
+  }
+
+  return cases;
+}
+
 function renderWithoutBrowserDocument(registry: ReturnType<typeof createRouteRegistry>): string {
   const descriptor = Object.getOwnPropertyDescriptor(globalThis, "document");
   Object.defineProperty(globalThis, "document", {
@@ -47,6 +76,23 @@ afterEach(() => {
 });
 
 describe("generated theme style hydration", () => {
+  it("should reject generated CSS comment-delimiter injections without mutating the shared registry", () => {
+    removeStyleRegistries();
+
+    for (const [index, value] of cssCommentInjectionCases().entries()) {
+      expect(styleDeclarationsToClass(`--ak-fuzz-${index}:${value}`), value).toBeUndefined();
+    }
+
+    expect(document.querySelector("style[data-askr-style-registry]")).toBeNull();
+    expect(styleDeclarationsToClass("color:blue")).toMatch(/^ak-style-/);
+    expect(document.querySelector("style[data-askr-style-registry]")?.textContent).toContain(
+      "color:blue",
+    );
+    expect(document.querySelector("style[data-askr-style-registry]")?.textContent).not.toContain(
+      "nested",
+    );
+  });
+
   it("should reject a new rule before exceeding the registry capacity", () => {
     removeStyleRegistries();
 


### PR DESCRIPTION
## Summary

- reject either CSS comment delimiter before generated declarations reach hashing, SSR collection, or the browser stylesheet registry
- preserve the existing valid CSS property/function contract
- add a deterministic seeded adversarial generator covering 312 delimiter-shaped values
- prove rejected values cannot create or mutate the shared registry and a later benign rule remains effective

## Linked issue

Closes #64

## TDD

- Red `508be0e`: the real jsdom registry guard failed on its first generated opener (`/*10u1pk5`), which received a generated class instead of being rejected.
- Green `ea8e30d`: a dedicated `/*` / `*/` lexical-state check rejects every generated case before registration.

## Security boundary

- Source: declaration values passed through `styleDeclarationsToClass()` / `serializeCssDeclarations()`.
- Sink: the shared browser stylesheet and SSR style collector.
- Invariant: an accepted value cannot contain a comment delimiter that changes lexical state across generated rule boundaries.
- Compatibility: existing custom properties, calculations, colors, gradients, transforms, and declaration lists remain accepted.
- Remaining risk: this remains a narrow generated-declaration sanitizer, not a general parser for arbitrary untrusted CSS.

## Guardrails

- deterministic seeded generation across openers, closers, start/middle/end placement, quotes, whitespace adjacency, repeated delimiters, and nested-looking sequences
- a real jsdom shared-registry assertion that rejected values do not create a registry
- a subsequent safe rule proves the rejected opener cannot suppress later generated CSS
- the guard runs in the normal jsdom/CI suite

## Acceptance audit

- [x] Every behavioral, compatibility, adversarial, and guardrail criterion in #64 is implemented locally.
- [x] Focused red and green states are recorded as separate commits.
- [x] Full local release gate and production dependency audit pass.
- [x] Every #64 checkbox is checked with exact-head hosted CI evidence before merge.
- [x] Exact squash merge, tag, publish workflow, and clean registry consumer are verified.

## Verification

- `npm run test:jsdom -- --run tests/jsdom/generated-style-ssr.test.tsx`
- `npm run test:unit -- --run tests/unit/layout-helpers.test.ts tests/unit/enhancement-contracts.test.ts`
- `npm run check`
- `npm audit --omit=dev`
