### PR TITLE
fix: isolate ThemeScope storage identities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -128,7 +128,7 @@ export function ThemeScope(props: ThemeScopeProps): JSX.Element {
   const ownedCoordinator = state<ThemeCoordinator>(getDefaultThemeCoordinator())();
   const coordinator = parentScope.coordinator ?? ownedCoordinator;
   const scopeDepth = parentScope.depth + 1;
-  coordinator.register(scopeId, scopeDepth, currentTheme, scopeSignal, (nextTheme) => {
+  coordinator.register(scopeId, scopeDepth, storageKey, currentTheme, scopeSignal, (nextTheme) => {
     if (themeState() !== nextTheme) themeState.set(nextTheme);
   });
 
@@ -235,6 +235,7 @@ function createThemeCoordinator() {
     symbol,
     {
       depth: number;
+      identity: string;
       sequence: number;
       theme: ThemeName;
       signal: AbortSignal;
@@ -296,6 +297,7 @@ function createThemeCoordinator() {
     register(
       id: symbol,
       depth: number,
+      identity: string,
       themeName: ThemeName,
       signal: AbortSignal,
       onThemeChange: (themeName: ThemeName) => void,
@@ -303,6 +305,7 @@ function createThemeCoordinator() {
       const existing = scopes.get(id);
       scopes.set(id, {
         depth,
+        identity,
         sequence: existing?.sequence ?? nextSequence++,
         theme: themeName,
         signal,
@@ -326,8 +329,13 @@ function createThemeCoordinator() {
       if (scope) scope.theme = themeName;
       explicitOwner = id;
       const ownerDepth = scope?.depth;
+      const ownerIdentity = scope?.identity;
       for (const [scopeId, registered] of scopes) {
-        if (scopeId !== id && registered.depth === ownerDepth) {
+        if (
+          scopeId !== id &&
+          registered.depth === ownerDepth &&
+          registered.identity === ownerIdentity
+        ) {
           registered.theme = themeName;
           registered.onThemeChange(themeName);
         }

--- a/tests/jsdom/theme-contract.test.tsx
+++ b/tests/jsdom/theme-contract.test.tsx
@@ -22,6 +22,8 @@ const THEME_STORAGE_KEYS = [
   "askr-theme-empty",
   "askr-theme-nested",
   "askr-theme-blocked",
+  "askr-theme-cross-root-a",
+  "askr-theme-cross-root-b",
   "askr-theme-remount-first",
   "askr-theme-remount-second",
 ] as const;
@@ -324,6 +326,63 @@ describe("theme contracts", () => {
       expect(second.querySelector('[data-slot="theme-probe"]')?.getAttribute("data-theme")).toBe(
         "dark",
       );
+    } finally {
+      cleanupApp(first);
+      cleanupApp(second);
+      first.remove();
+      second.remove();
+    }
+  });
+
+  it("should isolate same-depth independent roots given distinct theme storage identities", async () => {
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    document.body.append(first, second);
+    const FirstApp = () => (
+      <ThemeScope defaultTheme="light" storageKey="askr-theme-cross-root-a">
+        <ThemeToggle aria-label="Toggle first theme" />
+        <ThemeProbe />
+      </ThemeScope>
+    );
+    const SecondApp = () => (
+      <ThemeScope defaultTheme="light" storageKey="askr-theme-cross-root-b">
+        <ThemeToggle aria-label="Toggle second theme" />
+        <ThemeProbe />
+      </ThemeScope>
+    );
+    testRoute("/theme", FirstApp);
+    const firstRegistry = createTestRegistry();
+    resetTestRoutes();
+    testRoute("/theme", SecondApp);
+    const secondRegistry = createTestRegistry();
+
+    const probeTheme = (root: HTMLElement) =>
+      root.querySelector('[data-slot="theme-probe"]')?.getAttribute("data-theme");
+
+    try {
+      await createSPA({ root: first, registry: firstRegistry });
+      await createSPA({ root: second, registry: secondRegistry });
+      await settle();
+
+      (first.querySelector('[data-theme-control="toggle"]') as HTMLButtonElement).click();
+      await settle();
+
+      expect(probeTheme(first)).toBe("dark");
+      expect(probeTheme(second)).toBe("light");
+      expect(window.localStorage.getItem("askr-theme-cross-root-a")).toBe("dark");
+      expect(window.localStorage.getItem("askr-theme-cross-root-b")).toBeNull();
+      expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+
+      (second.querySelector('[data-theme-control="toggle"]') as HTMLButtonElement).click();
+      await settle();
+      (first.querySelector('[data-theme-control="toggle"]') as HTMLButtonElement).click();
+      await settle();
+
+      expect(probeTheme(first)).toBe("light");
+      expect(probeTheme(second)).toBe("dark");
+      expect(window.localStorage.getItem("askr-theme-cross-root-a")).toBe("light");
+      expect(window.localStorage.getItem("askr-theme-cross-root-b")).toBe("dark");
+      expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     } finally {
       cleanupApp(first);
       cleanupApp(second);


### PR DESCRIPTION
## Summary

- carry each `ThemeScope` storage identity into the shared document coordinator
- propagate same-depth explicit changes only to registrations with the same identity
- retain one document arbitration point so `documentElement[data-theme]` follows the latest explicit scope
- preserve same-key cross-root synchronization and nested depth precedence

## Linked issue

Closes #65

## TDD

- Red `f6b7dbd`: toggling root A changed distinct-key root B from light to dark while only A's key was persisted.
- Green `cf3dfb1`: identity-scoped peer propagation isolates the two local signals and stored values.

## Guardrails

- two real independent roots at the same depth with distinct keys
- bidirectional toggles check each signal and persisted value independently
- shared document target checked separately from local state
- existing same-key cross-root synchronization remains in the same suite
- existing nested, storage-event, remount, and persistence coverage remains green

## Acceptance audit

- [x] Every behavioral, compatibility, and guardrail criterion in #65 is implemented locally.
- [x] Focused red and green states are recorded as separate commits.
- [x] Full local release gate and production dependency audit pass.
- [x] Every #65 checkbox is checked with exact-head hosted CI evidence before merge.
- [x] Exact squash merge, tag, publish workflow, and clean registry consumer are verified.

## Verification

- `npm run test:jsdom -- --run tests/jsdom/theme-contract.test.tsx`
- `npm run typecheck`
- `npm run check`
- `npm audit --omit=dev`
