### PR TITLE
test: follow live command palette focus nodes

### DIFF
--- a/tests/browser/command-palette.test.tsx
+++ b/tests/browser/command-palette.test.tsx
@@ -107,10 +107,26 @@ describe("CommandPalette", () => {
     expect(link.parentElement?.parentElement?.tagName).toBe("UL");
     expect(document.activeElement).toBe(input);
 
-    await userEvent.tab({ shift: true });
-    await waitForElement(() => (document.activeElement === link ? link : null));
-    await userEvent.tab();
-    await waitForElement(() => (document.activeElement === input ? input : null));
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    await waitForElement(() => {
+      const currentLink = document.body.querySelector('[role="dialog"] a');
+      return currentLink && document.activeElement === currentLink ? currentLink : null;
+    });
+    const currentLink = document.body.querySelector('[role="dialog"] a') as HTMLAnchorElement;
+    currentLink.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }),
+    );
+    await waitForElement(() => {
+      const currentInput = document.body.querySelector('[role="dialog"] input');
+      return currentInput && document.activeElement === currentInput ? currentInput : null;
+    });
 
     await userEvent.keyboard("{Escape}");
     await settle();


### PR DESCRIPTION
## Summary

- make the command-palette focus-loop guard re-query live controls after reactive reconciliation
- dispatch bubbling, cancelable Shift+Tab/Tab key events through the real FocusScope handler without relying on provider-level tab-order emulation
- unblock the already-merged 0.0.29 release without changing package behavior or version

## TDD evidence

- Red: [publish run 31911124830](https://github.com/askrjs/askr-themes/actions/runs/31911124830) failed on Ubuntu because focus reached a reconciled control while the test retained its detached predecessor.
- Green: the three-engine focused suite passes repeated local runs while still requiring the live link/input to own `document.activeElement`.

## Permanent guardrail

- the integration test sends the real bubbling/cancelable Tab event shape through FocusScope and checks real DOM focus
- observation follows the live dialog nodes, matching the framework's reconciliation contract instead of treating node identity as stable

## Acceptance audit

- [x] The hosted red failure is linked and explained.
- [x] The focused three-engine regression passes repeated local runs.
- [x] Exact-head hosted CI succeeds on macOS, Windows, and Ubuntu in [run 31911892708](https://github.com/askrjs/askr-themes/actions/runs/31911892708).
- [x] The release blocker is ready to squash-merge before the 0.0.29 publish workflow is retried.
