### PR TITLE
test: harden command palette mount polling

### DIFF
--- a/tests/browser/command-palette.test.tsx
+++ b/tests/browser/command-palette.test.tsx
@@ -23,11 +23,14 @@ async function settle(): Promise<void> {
 }
 
 async function waitForElement<T extends Element>(read: () => T | null): Promise<T> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  const deadline = performance.now() + 5_000;
+
+  do {
     const element = read();
     if (element) return element;
     await settle();
-  }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  } while (performance.now() < deadline);
 
   throw new Error("Expected command palette element to mount");
 }


### PR DESCRIPTION
## Summary

- replace the command-palette guard's fixed 20-frame mount budget with a bounded five-second wall-clock deadline
- yield both a render frame and a short timer turn between observations so overloaded hosted runners cannot exhaust the guard in a burst
- keep the wait finite and preserve the real keyboard/focus assertions that blocked the 0.0.29 release

## TDD evidence

- Red: [publish run 31912043677](https://github.com/askrjs/askr-themes/actions/runs/31912043677) failed on Ubuntu at the second keyboard-open mount observation after the original 20-frame budget expired.
- Green: the focused command-palette suite passed 10 consecutive local three-engine runs (150 assertions), then the complete local `npm run check` gate passed (591 unit, 2 policy, 59 jsdom, 195 browser, and forced-colors coverage plus build/package/bundle checks).

## Permanent guardrail

- every command-palette DOM/focus observation still re-queries live reconciled nodes
- the helper now uses a real bounded deadline rather than assuming a fixed number of animation frames corresponds to sufficient hosted-runner time
- the guard still fails hard after five seconds, so a genuinely missing mount cannot be hidden

## Acceptance audit

- [x] The exact hosted red failure is linked and explained.
- [x] The focused three-engine regression passes repeatedly.
- [x] The full local release gate passes.
- [x] Exact-head hosted CI succeeds on macOS, Windows, and Ubuntu in [run 31912278134](https://github.com/askrjs/askr-themes/actions/runs/31912278134).
- [x] This blocker is ready to squash-merge before the 0.0.29 publish workflow is retried.
