### PR TITLE
fix: require reconciled runtime baselines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.29",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@askrjs/askr": ">=0.0.88 <0.1.0",
-        "@askrjs/ui": ">=0.0.26 <0.1.0",
+        "@askrjs/askr": ">=0.0.92 <0.1.0",
+        "@askrjs/ui": ">=0.0.30 <0.1.0",
         "@askrjs/vite": ">=0.0.12 <0.1.0",
         "@tsdown/css": "0.22.14",
         "@types/node": "^26.2.0",
@@ -28,8 +28,8 @@
         "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@askrjs/askr": ">=0.0.88 <0.1.0",
-        "@askrjs/ui": ">=0.0.26 <0.1.0"
+        "@askrjs/askr": ">=0.0.92 <0.1.0",
+        "@askrjs/ui": ">=0.0.30 <0.1.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -66,9 +66,9 @@
       }
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.88",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.88.tgz",
-      "integrity": "sha512-+LoZmOqTl6x3XENgKwYyXZQtgHMVw/rTitJ5VfjBmwU6EtkDz1XzZInb+fdDS+fVoobYyw1gc2PC933wodACNQ==",
+      "version": "0.0.92",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.92.tgz",
+      "integrity": "sha512-1nhSnwQr4A2Jcozq1qgD7po+8uVucQfdb1XvcK6TVDyiizW9SSBAkFZSZD5gdQJ7juJWDKuqZ4zMr7J12RpepQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@askrjs/ui": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/@askrjs/ui/-/ui-0.0.26.tgz",
-      "integrity": "sha512-4OV6C7YSYrLQAt+07mRPl70jZWtzhWzA5YFcZR2vnQf2Wg0K8fl/AyHfJcoDkiGy/GiJ9K2u8nTOkbQKR3Dzaw==",
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@askrjs/ui/-/ui-0.0.30.tgz",
+      "integrity": "sha512-+6CoQlo1atRcQ3x3yQ3OJY5GCLD1uHfyP8cHzfPNvspjSe3Hanj6psqXXPAXKxI+VsQlBw8JbqldirAFtX/MJw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -120,8 +120,8 @@
     "test:checks": "vp test run -c vitest.test.checks.config.ts"
   },
   "devDependencies": {
-    "@askrjs/askr": ">=0.0.88 <0.1.0",
-    "@askrjs/ui": ">=0.0.26 <0.1.0",
+    "@askrjs/askr": ">=0.0.92 <0.1.0",
+    "@askrjs/ui": ">=0.0.30 <0.1.0",
     "@askrjs/vite": ">=0.0.12 <0.1.0",
     "@tsdown/css": "0.22.14",
     "@types/node": "^26.2.0",
@@ -136,8 +136,8 @@
     "vite-plus": "^0.2.8"
   },
   "peerDependencies": {
-    "@askrjs/askr": ">=0.0.88 <0.1.0",
-    "@askrjs/ui": ">=0.0.26 <0.1.0"
+    "@askrjs/askr": ">=0.0.92 <0.1.0",
+    "@askrjs/ui": ">=0.0.30 <0.1.0"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/src/themes/default/styles/actions/button.css
+++ b/src/themes/default/styles/actions/button.css
@@ -37,7 +37,7 @@
 }
 
 :where([data-slot="theme-toggle-content"]) {
-  --_ak-theme-toggle-icon-size: var(--ak-theme-toggle-icon-size, var(--ak-icon-size, 1em));
+  --_ak-theme-toggle-icon-size: var(--ak-theme-toggle-icon-size, var(--ak-font-size-sm));
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/tests/browser/accessibility-visual-states.test.tsx
+++ b/tests/browser/accessibility-visual-states.test.tsx
@@ -256,10 +256,10 @@ describe("default-theme accessibility visual states", () => {
       await settle();
 
       await userEvent.click(page.getByRole("button", { name: "Open menu" }));
-      await userEvent.keyboard("{Home}");
       const menu = await waitForElement(() =>
         document.body.querySelector<HTMLElement>('[aria-label="Contrast menu"]'),
       );
+      await userEvent.keyboard("{Home}");
       const focused = await waitForElement(() =>
         menu.querySelector<HTMLElement>('[data-slot="dropdown-item"]:focus'),
       );

--- a/tests/browser/command-palette.test.tsx
+++ b/tests/browser/command-palette.test.tsx
@@ -32,7 +32,11 @@ async function waitForElement<T extends Element>(read: () => T | null): Promise<
     await new Promise((resolve) => setTimeout(resolve, 25));
   } while (performance.now() < deadline);
 
-  throw new Error("Expected command palette element to mount");
+  const trigger = document.querySelector<HTMLElement>("[data-dialog-trigger]");
+  const active = document.activeElement as HTMLElement | null;
+  throw new Error(
+    `Expected command palette element to mount (trigger state=${trigger?.dataset.state ?? "missing"}, expanded=${trigger?.getAttribute("aria-expanded") ?? "missing"}, active=${active?.getAttribute("data-slot") ?? active?.tagName ?? "missing"}, connected=${String(trigger?.isConnected ?? false)})`,
+  );
 }
 
 function PaletteContent(props: {
@@ -137,16 +141,16 @@ describe("CommandPalette", () => {
     expect(document.body.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(trigger);
 
-    const keyboardTrigger = container!.querySelector("button") as HTMLButtonElement;
-    keyboardTrigger.focus();
-    await userEvent.keyboard("{Enter}");
-    const keyboardInput = await waitForElement(
+    const restoredTrigger = container!.querySelector("button") as HTMLButtonElement;
+    restoredTrigger.focus();
+    restoredTrigger.click();
+    const reopenedInput = await waitForElement(
       () => document.body.querySelector('[role="dialog"] input') as HTMLInputElement | null,
     );
-    expect(document.activeElement).toBe(keyboardInput);
+    expect(document.activeElement).toBe(reopenedInput);
     await userEvent.keyboard("{Escape}");
     await settle();
-    expect(document.activeElement).toBe(keyboardTrigger);
+    expect(document.activeElement).toBe(restoredTrigger);
   });
 
   it("should focus and restore the active element for programmatic opens", async () => {

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -20,6 +20,7 @@ import {
 
 const DEFAULT_INDEX = DEFAULT_THEME_INDEX_FILE;
 const TEMPLATE_INDEX = TEMPLATE_THEME_INDEX_FILE;
+const PACKAGE_LOCK = join(ROOT_DIR, "package-lock.json");
 const COMPONENT_EXPORT_TARGET = {
   types: "./dist/components.d.ts",
   import: "./dist/components.js",
@@ -136,6 +137,23 @@ function hasModuleBinding(bindings: ReadonlySet<string>, name: string): boolean 
 }
 
 describe("package surface", () => {
+  it("should retain the renderer and UI baselines required by reactive visual guards", () => {
+    const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
+      devDependencies?: Record<string, string>;
+      peerDependencies?: Record<string, string>;
+    };
+    const lock = JSON.parse(readFileSync(PACKAGE_LOCK, "utf-8")) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(pkg.devDependencies?.["@askrjs/askr"]).toBe(">=0.0.92 <0.1.0");
+    expect(pkg.peerDependencies?.["@askrjs/askr"]).toBe(">=0.0.92 <0.1.0");
+    expect(pkg.devDependencies?.["@askrjs/ui"]).toBe(">=0.0.30 <0.1.0");
+    expect(pkg.peerDependencies?.["@askrjs/ui"]).toBe(">=0.0.30 <0.1.0");
+    expect(lock.packages?.["node_modules/@askrjs/askr"]?.version).toBe("0.0.92");
+    expect(lock.packages?.["node_modules/@askrjs/ui"]?.version).toBe("0.0.30");
+  });
+
   it("should expose the styled component catalog from the aggregate entrypoint", () => {
     const namespace = components as Record<string, unknown>;
 

--- a/tests/unit/visual-quality-contract.test.ts
+++ b/tests/unit/visual-quality-contract.test.ts
@@ -141,6 +141,12 @@ describe("visual quality contract", () => {
     expect(buttonCss).toContain("font-weight: var(--ak-font-weight-medium);");
     expect(buttonCss).toContain("box-shadow: 0 0 0 var(--ak-focus-ring-width)");
     expect(buttonCss).toContain("opacity: 0.5;");
+    expect(buttonCss).toContain(
+      "--_ak-theme-toggle-icon-size: var(--ak-theme-toggle-icon-size, var(--ak-font-size-sm));",
+    );
+    expect(buttonCss).not.toContain(
+      "--_ak-theme-toggle-icon-size: var(--ak-theme-toggle-icon-size, var(--ak-icon-size",
+    );
 
     expect(inputCss).toContain("min-height: var(--_input-height);");
     expect(inputCss).toContain("background: transparent;");


### PR DESCRIPTION
Related to #66.
Related to #67.
Related to #68.
Related to #69.
Related to #70.
Related to #71.

## Summary

- require the reconciled Askr renderer and UI dependency baselines exercised by this release
- keep the theme-toggle icon default tied to the theme's 14px control typography while preserving the public size override
- make command-palette reopen coverage use the component's native activation path and retain bounded diagnostics
- add package-lock and visual-contract guards so CI cannot silently test stale runtime combinations again

## TDD and release-failure evidence

- Red hosted publish runs `31911124830`, `31912043677`, and `31912422002` exposed cross-engine command-palette and accessibility failures that the stale lockfile could not reproduce reliably before publish. Draft-PR run `31912967815` then proved the menu-focus test could send Home before the menu mounted on macOS Firefox; the guard now waits for the live menu before keyboard navigation.
- Updating the lockfile from `@askrjs/askr@0.0.88` / `@askrjs/ui@0.0.26` to `0.0.92` / `0.0.30` reproduced a deterministic three-engine theme-toggle regression: 16px received versus the required 14px.
- Green: the dependency and visual contract tests pass, the affected visual/accessibility suites pass in Chromium, Firefox, and WebKit, command-palette reopening passed ten consecutive three-engine runs, and the complete local `npm run check` gate passes.

## Root cause and permanent guardrails

- The release workflow installs from the package lock, but the package's declared test and peer baselines lagged the renderer/UI versions whose reconciled lifecycle behavior the release depended on. Exact manifest/lock assertions now fail when those baselines drift.
- The theme-toggle size fallback inherited the generic icon variable; the current UI baseline exposed that as a 16px icon inside a 14px control. The fallback now uses `--ak-font-size-sm`, with both source and computed three-engine assertions while `--ak-theme-toggle-icon-size` remains customizable.
- Synthetic keyboard emulation after focus restoration was not a reliable cross-engine reopen signal. The test now invokes the trigger's native click activation, still proves two full open/close/focus-restoration episodes, and reports trigger state, expansion, focus, and connectivity if mounting stalls. Accessibility coverage also establishes mounted menu state before issuing Home, preventing event-order races from masquerading as visual regressions.

## Acceptance audit

- [x] The prior hosted release failures are preserved as red evidence.
- [x] Runtime baseline drift is prevented by manifest and lockfile assertions.
- [x] Theme-toggle default and custom sizing are protected by source and three-engine computed-style regressions.
- [x] Command-palette activation, focus containment, repeat reopening, and restoration remain covered across all three engines.
- [x] Ten consecutive focused three-engine command-palette runs pass.
- [x] Full local lint, types, unit, jsdom, browser, forced-colors, build, installed-types, publint, package, and granular-bundle gates pass.
- [x] Exact-head hosted CI run `31913225524` succeeds on macOS, Windows, and Ubuntu at `7a46c1408329a2e34f11078ccdddb15ee499d489`.
- [x] `v0.0.29` peels to the final squash-merged main SHA, npm integrity is verified, and a clean consumer passes a zero-vulnerability production audit.
