### PR TITLE
docs: define styling-only catalog wrapper contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ diverge instead of emitting unstyled markup. Use the same wrapper for an SSR
 - `@askrjs/charts` for charts; chart components are intentionally not exported
   from `@askrjs/themes`.
 
+### Styling-only compatibility wrappers
+
+`DataTable`, `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle`
+are styling-only catalog compatibility wrappers. Their names do not promise a
+data-grid or panel-resizing runtime:
+
+- `DataTable` provides a `data-table` container slot. It does not sort, filter,
+  select, or paginate. Compose semantic `Table` or `VirtualTable` primitives
+  from `@askrjs/ui` and keep data operations in application-owned state.
+- `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle` provide layout
+  and separator slots only. The group does not implement pointer or keyboard
+  resizing, track dimensions, or provide the ARIA value state required by an
+  interactive splitter.
+
+These names remain exported for catalog compatibility. If an application needs
+real resize behavior today, supply the pointer, keyboard, sizing, and ARIA
+contract in application code or a dedicated behavior dependency. A future Askr
+resize primitive must be implemented and tested in `@askrjs/ui` before themes
+can compose and style it.
+
 ## Theme Contract
 
 - Style public `data-*` hooks and token variables, not internal DOM structure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,24 @@ Those wrappers are visual composition. They arrange or style existing controls,
 but they do not own the interaction model. That makes them a good fit for the
 theme package.
 
+## Styling-only compatibility wrappers
+
+Four catalog names are intentionally visual rather than behavioral:
+`DataTable`, `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle`.
+They are retained to keep the public catalog backward compatible, but they do
+not stand in for missing `@askrjs/ui` primitives.
+
+`DataTable` is a container slot and does not sort, filter, select, or paginate.
+Applications should compose the semantic `Table` or `VirtualTable` primitives
+from `@askrjs/ui` and own their data state explicitly. The resizable wrappers
+are layout/separator slots; the group does not implement pointer or keyboard
+resizing, dimension state, or interactive-splitter ARIA values. Applications
+that need those behaviors must provide a complete behavior implementation.
+
+Do not add behavior-looking props to these wrappers. If Askr gains a resizable
+primitive, implement its state, pointer and keyboard interaction, focus, ARIA,
+and browser regressions in `@askrjs/ui`; themes may then re-export and style it.
+
 ## Adding A New Component
 
 When a surface needs behavior:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.92 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -435,7 +435,10 @@ export function CommandShortcut(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "command-shortcut", element: "span" });
 }
 
-/** Renders the `data-table` part of the shadcn-compatible catalog primitives. */
+/**
+ * Styling-only container for the `data-table` catalog slot. It does not sort, filter, select, or paginate data.
+ * Compose semantic `Table`/`VirtualTable` primitives with application-owned data state for those behaviors.
+ */
 export function DataTable(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "data-table" });
 }
@@ -729,17 +732,20 @@ export function PaginationEllipsis(props: CatalogComponentProps): JSX.Element {
   );
 }
 
-/** Renders the `resizable-panel-group` part of the shadcn-compatible catalog primitives. */
+/**
+ * Styling-only container for the `resizable-panel-group` catalog slot. It does not implement resizing.
+ * Consumers own pointer, keyboard, sizing, and ARIA state until a behavior primitive exists in `@askrjs/ui`.
+ */
 export function ResizablePanelGroup(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "resizable-panel-group" });
 }
 
-/** Renders the `resizable-panel` part of the shadcn-compatible catalog primitives. */
+/** Styling-only `resizable-panel` slot; it does not implement resizing or manage panel dimensions. */
 export function ResizablePanel(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "resizable-panel" });
 }
 
-/** Renders the `resizable-handle` part of the shadcn-compatible catalog primitives. */
+/** Styling-only separator slot; it does not implement resizing, pointer dragging, or keyboard controls. */
 export function ResizableHandle(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "resizable-handle", role: "separator" });
 }

--- a/tests/unit/docs-surface.test.ts
+++ b/tests/unit/docs-surface.test.ts
@@ -66,6 +66,19 @@ describe("docs surface", () => {
     expect(EXCLUDED_CHART_COMPONENT).toBe("Chart");
   });
 
+  it("should distinguish styling-only catalog compatibility names from behavior primitives", () => {
+    const docs = [readFileSync(README, "utf-8"), readFileSync(ARCHITECTURE_DOC, "utf-8")].join(
+      "\n",
+    );
+
+    expect(docs).toContain("Styling-only compatibility wrappers");
+    expect(docs).toContain("DataTable");
+    expect(docs).toContain("ResizablePanelGroup");
+    expect(docs).toContain("does not sort, filter, select, or paginate");
+    expect(docs).toContain("does not implement pointer or keyboard resizing");
+    expect(docs).toContain("@askrjs/ui");
+  });
+
   it("should keep external project attribution in acknowledgements, not source or tests", () => {
     const acknowledgements = readFileSync(ACKNOWLEDGEMENTS, "utf-8");
     const externalProjectNames = [...acknowledgements.matchAll(/^- \[([^\]]+)\]/gmu)].map(

--- a/tests/unit/docs-surface.test.ts
+++ b/tests/unit/docs-surface.test.ts
@@ -67,9 +67,9 @@ describe("docs surface", () => {
   });
 
   it("should distinguish styling-only catalog compatibility names from behavior primitives", () => {
-    const docs = [readFileSync(README, "utf-8"), readFileSync(ARCHITECTURE_DOC, "utf-8")].join(
-      "\n",
-    );
+    const docs = [readFileSync(README, "utf-8"), readFileSync(ARCHITECTURE_DOC, "utf-8")]
+      .join("\n")
+      .replace(/\s+/gu, " ");
 
     expect(docs).toContain("Styling-only compatibility wrappers");
     expect(docs).toContain("DataTable");

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -136,6 +136,13 @@ function hasModuleBinding(bindings: ReadonlySet<string>, name: string): boolean 
   return bindings.has(name) || bindings.has(WILDCARD_MODULE_BINDING);
 }
 
+function declarationDocumentation(source: string, component: string): string {
+  const declarationOffset = source.indexOf(`declare function ${component}`);
+  if (declarationOffset < 0) return "";
+  const documentationOffset = source.lastIndexOf("/**", declarationOffset);
+  return source.slice(documentationOffset, declarationOffset);
+}
+
 describe("package surface", () => {
   it("should retain the renderer and UI baselines required by reactive visual guards", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
@@ -270,6 +277,21 @@ describe("package surface", () => {
           `${artifact} should not source ${component} from @askrjs/ui`,
         ).toBe(false);
       }
+    }
+  }, 30_000);
+
+  it("should publish the styling-only contract for catalog names that imply behavior", () => {
+    ensureComponentDistArtifacts();
+    const declarations = readFileSync(join(ROOT_DIR, "dist/components.d.ts"), "utf-8");
+
+    const dataTableDocs = declarationDocumentation(declarations, "DataTable");
+    expect(dataTableDocs).toContain("Styling-only");
+    expect(dataTableDocs).toContain("does not sort, filter, select, or paginate");
+
+    for (const component of ["ResizablePanelGroup", "ResizablePanel", "ResizableHandle"]) {
+      const docs = declarationDocumentation(declarations, component);
+      expect(docs, component).toContain("Styling-only");
+      expect(docs, component).toContain("does not implement resizing");
     }
   }, 30_000);
 

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -282,7 +282,7 @@ describe("package surface", () => {
 
   it("should publish the styling-only contract for catalog names that imply behavior", () => {
     ensureComponentDistArtifacts();
-    const declarations = readFileSync(join(ROOT_DIR, "dist/components.d.ts"), "utf-8");
+    const declarations = readFileSync(join(ROOT_DIR, "dist/components/catalog.d.ts"), "utf-8");
 
     const dataTableDocs = declarationDocumentation(declarations, "DataTable");
     expect(dataTableDocs).toContain("Styling-only");


### PR DESCRIPTION
Closes #62.

## Summary

- resolve the catalog contract in favor of backward-compatible styling-only wrappers
- state explicitly that `DataTable` does not sort, filter, select, or paginate
- state explicitly that `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle` do not implement resizing
- direct behavioral implementations to `@askrjs/ui` and application-owned state without inventing unsupported props
- enforce the contract in shipped declarations and consumer documentation
- release `@askrjs/themes@0.0.30`

## TDD evidence

- Red `38cf13165b26aec6d0e16969a37814da422e8c02`: public-documentation and emitted-declaration regressions failed because the four names did not disclose their styling-only behavior boundary.
- Red harness correction `70bbfa6ece50cda0c54d5495bec8bc62c78c5a1a`: the declaration assertion follows the aggregate barrel into the emitted `dist/components/catalog.d.ts` file consumers actually reach; it remained red against the old JSDoc.
- Green `3d611c36cdbed7544b735b3dd180e1ed1b9239a3`: the same focused tests pass with explicit source JSDoc, emitted declaration documentation, README guidance, and architecture guidance.
- Full local gate: 594 unit tests, checks, 59 jsdom tests, 195 three-engine browser tests, forced-colors browser coverage, build, installed-types, publint, packed-artifact validation, and granular-bundle validation all passed. No runtime implementation changed, so runtime benchmarks are not applicable; `npm audit --omit=dev` reported 0 vulnerabilities.

## Contract decision and permanent guardrails

- These exports remain styling-only for backward compatibility. Removing or renaming them would break the existing catalog, while implementing stateful data-grid and splitter behavior inside themes would violate the repository's established boundary that `@askrjs/ui` owns behavior, focus, keyboard interaction, and ARIA.
- `DataTable` is documented as a visual container. Consumers compose semantic `Table` or `VirtualTable` primitives and own sorting/filtering/selection/pagination state.
- The resizable wrappers expose layout and separator slots only. They do not drag, resize from the keyboard, track dimensions, or supply interactive-splitter ARIA values; consumers must provide a complete behavior implementation until one exists in `@askrjs/ui`.
- A package-surface regression reads the emitted declaration artifact and requires each potentially misleading name to carry the negative behavior contract. A separate docs-surface regression requires the public README/architecture explanation and the correct `@askrjs/ui` ownership rule.
- Existing built-artifact guards continue to prove these four names come from the themes catalog rather than falsely appearing to be `@askrjs/ui` behavior primitives.

## Acceptance audit

- [x] Reporter ownership and the issue contract were read back from GitHub.
- [x] The styling-only versus behavioral decision is explicit and consistent with package architecture.
- [x] Red declaration/docs regressions precede the documentation implementation.
- [x] Emitted declarations and public docs state what the wrappers do and do not do.
- [x] Permanent package-surface and docs-surface guardrails cover future contract drift.
- [x] Full local release, package, cross-engine browser, and production-audit gates pass; runtime benchmarks are not applicable to documentation-only runtime output.
- [x] Exact-head hosted CI succeeds on macOS, Windows, and Ubuntu.
- [x] Every issue acceptance checkbox is checked with evidence before ready-for-review and squash merge.
- [x] `v0.0.30` peels to the squash-merged main SHA, npm integrity is verified, and a clean consumer reads the repaired declaration contract with a zero-vulnerability production audit.
