### PR TITLE
Preserve public theme contracts

### DIFF
--- a/src/entries/data-table.ts
+++ b/src/entries/data-table.ts
@@ -1,1 +1,7 @@
-export { DataTable } from "../components/catalog";
+import { DataTable as CatalogDataTable } from "../components/catalog";
+
+/**
+ * Styling-only container for the `data-table` catalog slot. It does not sort,
+ * filter, select, or paginate data.
+ */
+export const DataTable = CatalogDataTable;

--- a/src/themes/default/styles/display/virtual-list.css
+++ b/src/themes/default/styles/display/virtual-list.css
@@ -38,3 +38,9 @@
 :where([data-slot="virtual-list-row"][data-visible="false"]) {
   color: var(--ak-color-text-muted);
 }
+
+:where([data-slot="virtual-list-spacer"]) {
+  flex: 0 0 auto;
+  inline-size: 100%;
+  pointer-events: none;
+}

--- a/src/themes/default/styles/display/virtual-table.css
+++ b/src/themes/default/styles/display/virtual-table.css
@@ -81,6 +81,12 @@
   background: transparent;
 }
 
+:where([data-slot="virtual-table-cell-content"]) {
+  display: flex;
+  align-items: center;
+  min-inline-size: 0;
+}
+
 @media (max-width: 30rem) {
   :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
     padding: var(--ak-space-sm) var(--ak-space-xs);

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -51,17 +51,14 @@ const REPORTED_CATALOG_WRAPPERS = [
 ] as const;
 const COMPONENT_DIST_ARTIFACTS = ["dist/components.js", "dist/components.d.ts"] as const;
 const WILDCARD_MODULE_BINDING = "*" as const;
+let componentDistArtifactsBuilt = false;
 
 function npmCommand(): string {
   return process.platform === "win32" ? "npm.cmd" : "npm";
 }
 
 function ensureComponentDistArtifacts(): void {
-  const missingArtifacts = COMPONENT_DIST_ARTIFACTS.filter(
-    (artifact) => !existsSync(join(ROOT_DIR, artifact)),
-  );
-
-  if (missingArtifacts.length === 0) {
+  if (componentDistArtifactsBuilt) {
     return;
   }
 
@@ -70,6 +67,7 @@ function ensureComponentDistArtifacts(): void {
     shell: process.platform === "win32",
     stdio: "ignore",
   });
+  componentDistArtifactsBuilt = true;
 }
 
 function addNamedBindings(
@@ -287,6 +285,13 @@ describe("package surface", () => {
     const dataTableDocs = declarationDocumentation(declarations, "DataTable");
     expect(dataTableDocs).toContain("Styling-only");
     expect(dataTableDocs).toContain("does not sort, filter, select, or paginate");
+
+    const entryDeclaration = readFileSync(
+      join(ROOT_DIR, "dist/entries/data-table.d.ts"),
+      "utf-8",
+    );
+    expect(entryDeclaration).toContain("Styling-only");
+    expect(entryDeclaration).toContain("does not sort");
 
     for (const component of ["ResizablePanelGroup", "ResizablePanel", "ResizableHandle"]) {
       const docs = declarationDocumentation(declarations, component);

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -286,10 +286,7 @@ describe("package surface", () => {
     expect(dataTableDocs).toContain("Styling-only");
     expect(dataTableDocs).toContain("does not sort, filter, select, or paginate");
 
-    const entryDeclaration = readFileSync(
-      join(ROOT_DIR, "dist/entries/data-table.d.ts"),
-      "utf-8",
-    );
+    const entryDeclaration = readFileSync(join(ROOT_DIR, "dist/entries/data-table.d.ts"), "utf-8");
     expect(entryDeclaration).toContain("Styling-only");
     expect(entryDeclaration).toContain("does not sort");
 

--- a/tests/unit/slot-coverage.test.ts
+++ b/tests/unit/slot-coverage.test.ts
@@ -49,7 +49,15 @@ const ALLOWED_THEME_ONLY_SLOTS = new Set([
   "tabs",
   "theme-scope",
   "toast-icon",
+  // Present in current askr-ui source but not yet in every compatible published version.
+  "virtual-list-spacer",
+  "virtual-table-cell-content",
 ]);
+
+const REQUIRED_FORWARD_COMPATIBLE_UI_SLOTS = [
+  "virtual-list-spacer",
+  "virtual-table-cell-content",
+] as const;
 
 const ALLOWED_UNCOVERED_UI_SLOTS = new Set([
   "collapsible",
@@ -218,6 +226,12 @@ describe("slot coverage", () => {
       uncovered,
       `Uncovered slots (in askr-ui but not in theme): ${uncovered.join(", ")}`,
     ).toEqual([]);
+  });
+
+  it("should cover required slots from newer compatible askr-ui versions", () => {
+    for (const slot of REQUIRED_FORWARD_COMPATIBLE_UI_SLOTS) {
+      expect(themeSlots.has(slot), `Missing forward-compatible UI slot: ${slot}`).toBe(true);
+    }
   });
 
   it("should not leave stale theme-only slots", () => {


### PR DESCRIPTION
## Summary
- preserve the styling-only DataTable contract in its emitted entry declaration
- rebuild declaration artifacts before declaration-level assertions
- style the virtual-list spacer and virtual-table cell-content slots
- rely on mechanical UI-slot-to-theme parity coverage

## Validation
- npm run check

Closes #79
Closes #80