### PR TITLE
fix: align theme accessibility and table styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/themes",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.2.0 <0.3.0",
@@ -16,6 +16,7 @@
         "@types/node": "^26.2.0",
         "@typescript/native": "npm:typescript@^7.0.2",
         "@vitest/browser-playwright": "4.1.10",
+        "axe-core": "^4.13.0",
         "cross-env": "^10.1.0",
         "jsdom": "^30.0.1",
         "playwright": "^1.62.1",
@@ -3669,6 +3670,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/bidi-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/themes",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Default theme tokens, styles, and component presets for Askr apps.",
   "keywords": [
     "askr",
@@ -127,6 +127,7 @@
     "@types/node": "^26.2.0",
     "@typescript/native": "npm:typescript@^7.0.2",
     "@vitest/browser-playwright": "4.1.10",
+    "axe-core": "^4.13.0",
     "cross-env": "^10.1.0",
     "jsdom": "^30.0.1",
     "playwright": "^1.62.1",

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -73,12 +73,13 @@ function buttonPart(props: CatalogComponentProps, slot: string, className?: stri
 }
 
 type LegacySpace = BlockSpace | "none" | "1" | "2" | "3" | "4" | "5" | "6" | "8";
+type LegacyWrap = boolean | "wrap" | "nowrap";
 
 type LegacyLayoutConveniences = {
   gap?: BlockResponsiveValue<LegacySpace>;
   p?: BlockResponsiveValue<LegacySpace>;
   padding?: BlockResponsiveValue<LegacySpace>;
-  wrap?: BlockResponsiveValue<boolean>;
+  wrap?: BlockResponsiveValue<LegacyWrap>;
 };
 
 type LegacyStructuralProps = Partial<
@@ -162,8 +163,49 @@ function normalizeLegacyResponsiveSpace(
   return normalizeLegacySpace(value);
 }
 
-function layoutAlias(props: LegacyLayoutProps, defaults: Record<string, unknown>): JSX.Element {
-  const { gap, p, padding, ...rest } = props as LegacyLayoutProps & Record<string, unknown>;
+function normalizeLegacyWrap(value: LegacyWrap): boolean {
+  if (value === "wrap") return true;
+  if (value === "nowrap") return false;
+  return value;
+}
+
+function normalizeLegacyResponsiveWrap(
+  value: BlockResponsiveValue<LegacyWrap> | undefined,
+): BlockResponsiveValue<boolean> | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([breakpoint, wrap]) => [
+        breakpoint,
+        normalizeLegacyWrap(wrap as LegacyWrap),
+      ]),
+    );
+  }
+  return normalizeLegacyWrap(value);
+}
+
+const warnedLegacyLayouts = new Set<string>();
+
+function warnDeprecatedLayout(component: string, replacement: string) {
+  const metaEnvironment = (import.meta as ImportMeta & { env?: { DEV?: boolean } }).env;
+  const nodeEnvironment = (
+    globalThis as typeof globalThis & { process?: { env?: { NODE_ENV?: string } } }
+  ).process?.env?.NODE_ENV;
+
+  if (metaEnvironment?.DEV !== true && nodeEnvironment !== "development") return;
+  if (warnedLegacyLayouts.has(component)) return;
+  warnedLegacyLayouts.add(component);
+  console.warn(`[askr-themes] ${component} is deprecated. ${replacement}`);
+}
+
+function layoutAlias(
+  component: string,
+  replacement: string,
+  props: LegacyLayoutProps,
+  defaults: Record<string, unknown>,
+): JSX.Element {
+  warnDeprecatedLayout(component, replacement);
+  const { gap, p, padding, wrap, ...rest } = props as LegacyLayoutProps & Record<string, unknown>;
   const BlockComponent = Block as (blockProps: Record<string, unknown>) => JSX.Element;
 
   return (
@@ -172,6 +214,7 @@ function layoutAlias(props: LegacyLayoutProps, defaults: Record<string, unknown>
       {...rest}
       gap={normalizeLegacyResponsiveSpace(gap)}
       padding={normalizeLegacyResponsiveSpace(padding ?? p)}
+      wrap={normalizeLegacyResponsiveWrap(wrap)}
     />
   );
 }
@@ -179,19 +222,19 @@ function layoutAlias(props: LegacyLayoutProps, defaults: Record<string, unknown>
 /** @deprecated Use {@link Block} directly. */
 export function Box(props: LegacyLayoutProps): JSX.Element;
 export function Box(props: LegacyLayoutProps): JSX.Element {
-  return layoutAlias(props, {});
+  return layoutAlias("Box", "Use Block directly.", props, {});
 }
 
 /** @deprecated Use `<Block direction="column">`. */
 export function Stack(props: LegacyLayoutProps): JSX.Element;
 export function Stack(props: LegacyLayoutProps): JSX.Element {
-  return layoutAlias(props, { direction: "column" });
+  return layoutAlias("Stack", 'Use <Block direction="column">.', props, { direction: "column" });
 }
 
 /** @deprecated Use `<Block direction="row">`. */
 export function Inline(props: LegacyLayoutProps): JSX.Element;
 export function Inline(props: LegacyLayoutProps): JSX.Element {
-  return layoutAlias(props, { direction: "row" });
+  return layoutAlias("Inline", 'Use <Block direction="row">.', props, { direction: "row" });
 }
 
 /** @deprecated Compose semantic {@link Block} primitives instead. */
@@ -199,19 +242,22 @@ export function Shell(props: LegacyLayoutProps & { variant?: string }): JSX.Elem
 export function Shell(props: LegacyLayoutProps & { variant?: string }): JSX.Element {
   const { variant: _variant, ...rest } = props;
   void _variant;
-  return layoutAlias(rest, {});
+  return layoutAlias("Shell", "Compose semantic Block primitives instead.", rest, {});
 }
 
 /** @deprecated Use `<Block as="nav">`. */
 export function ShellNav(props: LegacyLayoutProps): JSX.Element;
 export function ShellNav(props: LegacyLayoutProps): JSX.Element {
-  return layoutAlias(props, {});
+  return layoutAlias("ShellNav", 'Use <Block as="nav">.', props, {});
 }
 
 /** @deprecated Use `<Block as="main" grow>`. */
 export function ShellMain(props: LegacyLayoutProps): JSX.Element;
 export function ShellMain(props: LegacyLayoutProps): JSX.Element {
-  return layoutAlias(props, { as: "main", grow: true });
+  return layoutAlias("ShellMain", 'Use <Block as="main" grow>.', props, {
+    as: "main",
+    grow: true,
+  });
 }
 
 /** Renders the `alert-title` part of the shadcn-compatible catalog primitives. */
@@ -230,7 +276,14 @@ export function AlertDescription(props: CatalogComponentProps): JSX.Element {
 
 /** Renders the `breadcrumb` part of the shadcn-compatible catalog primitives. */
 export function Breadcrumb(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "breadcrumb", element: "nav", role: "navigation" });
+  return catalogPart(
+    { "aria-label": "Breadcrumb", ...props },
+    {
+      slot: "breadcrumb",
+      element: "nav",
+      role: "navigation",
+    },
+  );
 }
 
 /** Renders the `breadcrumb-list` part of the shadcn-compatible catalog primitives. */
@@ -325,12 +378,12 @@ export function CalendarNextButton(props: CatalogComponentProps): JSX.Element {
 
 /** Renders the `calendar-grid` part of the shadcn-compatible catalog primitives. */
 export function CalendarGrid(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "calendar-grid", role: "grid" });
+  return catalogPart(props, { slot: "calendar-grid" });
 }
 
 /** Renders the `calendar-head` part of the shadcn-compatible catalog primitives. */
 export function CalendarHead(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "calendar-head", role: "row" });
+  return catalogPart(props, { slot: "calendar-head" });
 }
 
 /** Renders the `calendar-body` part of the shadcn-compatible catalog primitives. */
@@ -340,12 +393,12 @@ export function CalendarBody(props: CatalogComponentProps): JSX.Element {
 
 /** Renders the `calendar-row` part of the shadcn-compatible catalog primitives. */
 export function CalendarRow(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "calendar-row", role: "row" });
+  return catalogPart(props, { slot: "calendar-row" });
 }
 
 /** Renders the `calendar-cell` part of the shadcn-compatible catalog primitives. */
 export function CalendarCell(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "calendar-cell", role: "gridcell" });
+  return catalogPart(props, { slot: "calendar-cell" });
 }
 
 /** Renders a single selectable day cell in the calendar grid, with selection/range/today state exposed as data attributes. */
@@ -365,7 +418,6 @@ export function CalendarDay(
     {
       disabled,
       "aria-disabled": disabled ? "true" : undefined,
-      "aria-selected": selected ? "true" : undefined,
       "data-disabled": disabled ? "" : undefined,
       "data-outside": outside ? "true" : undefined,
       "data-range-end": rangeEnd ? "true" : undefined,
@@ -411,14 +463,13 @@ export function Combobox(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "combobox" });
 }
 
-/** Renders the combobox's text input, wired up with `role="combobox"`. */
+/** Styling-only combobox input; consumers supplying behavior also own its complete ARIA contract. */
 export function ComboboxInput(props: CatalogComponentProps): JSX.Element {
   const { ref, class: className, ...rest } = props;
   const finalProps = mergeProps(rest, {
     ref,
     class: classes("input", className),
     "data-slot": "combobox-input",
-    role: "combobox",
   });
 
   return <input {...finalProps} />;
@@ -426,12 +477,12 @@ export function ComboboxInput(props: CatalogComponentProps): JSX.Element {
 
 /** Renders the `combobox-list` part of the shadcn-compatible catalog primitives. */
 export function ComboboxList(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "combobox-list", role: "listbox" });
+  return catalogPart(props, { slot: "combobox-list" });
 }
 
 /** Renders the `combobox-option` part of the shadcn-compatible catalog primitives. */
 export function ComboboxOption(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "combobox-option", role: "option" });
+  return catalogPart(props, { slot: "combobox-option" });
 }
 
 /** Renders the `command` part of the shadcn-compatible catalog primitives. */
@@ -463,7 +514,7 @@ export function CommandHeader(props: CatalogComponentProps): JSX.Element {
 
 /** Renders the `command-list` part of the shadcn-compatible catalog primitives. */
 export function CommandList(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "command-list", role: "listbox" });
+  return catalogPart(props, { slot: "command-list" });
 }
 
 /** Renders the `command-empty` part of the shadcn-compatible catalog primitives. */
@@ -489,12 +540,11 @@ export function CommandItem(
   return catalogPart(
     {
       "aria-disabled": disabled ? "true" : undefined,
-      "aria-selected": selected || active ? "true" : undefined,
       "data-disabled": disabled ? "" : undefined,
       "data-selected": selected || active ? "true" : undefined,
       ...rest,
     },
-    { slot: "command-item", role: "option" },
+    { slot: "command-item" },
   );
 }
 
@@ -755,7 +805,14 @@ export function NavigationMenuIndicator(props: CatalogComponentProps): JSX.Eleme
 
 /** Renders the `pagination` part of the shadcn-compatible catalog primitives. */
 export function Pagination(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "pagination", element: "nav", role: "navigation" });
+  return catalogPart(
+    { "aria-label": "Pagination", ...props },
+    {
+      slot: "pagination",
+      element: "nav",
+      role: "navigation",
+    },
+  );
 }
 
 /** Renders the `pagination-content` part of the shadcn-compatible catalog primitives. */
@@ -820,12 +877,12 @@ export function ResizablePanel(props: CatalogComponentProps): JSX.Element {
 
 /** Styling-only separator slot; it does not implement resizing, pointer dragging, or keyboard controls. */
 export function ResizableHandle(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "resizable-handle", role: "separator" });
+  return catalogPart(props, { slot: "resizable-handle" });
 }
 
 /** Renders the `tabs-list` part of the shadcn-compatible catalog primitives. */
 export function TabsList(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "tabs-list", role: "tablist" });
+  return catalogPart(props, { slot: "tabs-list" });
 }
 
 /** Renders the `tabs-content` part of the shadcn-compatible catalog primitives. */
@@ -835,7 +892,7 @@ export function TabsTrigger(props: CatalogComponentProps): JSX.Element {
 
 /** Renders the `tabs-content` part of the shadcn-compatible catalog primitives. */
 export function TabsContent(props: CatalogComponentProps): JSX.Element {
-  return catalogPart(props, { slot: "tabs-content", role: "tabpanel" });
+  return catalogPart(props, { slot: "tabs-content" });
 }
 
 /** Sheet variant of the dialog content part; defaults to sliding in from the right. */

--- a/src/themes/default/styles/base/reset.css
+++ b/src/themes/default/styles/base/reset.css
@@ -22,6 +22,10 @@
   display: block;
 }
 
+:where([data-askr-native-control="true"]) {
+  font: inherit;
+}
+
 ::selection {
   background: color-mix(in srgb, var(--ak-color-primary-soft) 84%, transparent);
   color: var(--ak-color-text);

--- a/src/themes/default/styles/display/table.css
+++ b/src/themes/default/styles/display/table.css
@@ -3,13 +3,12 @@
   min-inline-size: 0;
   border-collapse: collapse;
   border-spacing: 0;
-  table-layout: fixed;
+  table-layout: auto;
   border: 0;
   border-radius: 0;
   background: transparent;
   color: var(--ak-color-text);
   box-shadow: none;
-  overflow: hidden;
 }
 
 :where([data-slot="data-table"]) {
@@ -19,16 +18,16 @@
 }
 
 :where([data-slot="table-caption"]) {
-  padding: 0 0 var(--ak-space-sm);
+  padding-block-start: var(--ak-space-md);
   color: var(--ak-color-text-muted);
   font-size: var(--ak-font-size-sm);
   line-height: var(--ak-line-height-normal);
   text-align: start;
-  caption-side: top;
+  caption-side: bottom;
 }
 
 :where([data-slot="table-head"]) {
-  background: var(--ak-color-surface-muted);
+  background: transparent;
 }
 
 :where([data-slot="table-body"]) {
@@ -36,58 +35,60 @@
 }
 
 :where([data-slot="table-foot"]) {
-  background: transparent;
+  border-block-start: 1px solid var(--ak-color-border);
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
+  font-weight: var(--ak-font-weight-medium);
 }
 
 :where([data-slot="table-row"]) {
   background: inherit;
+  border-block-end: 1px solid var(--ak-color-border);
   transition: background var(--ak-duration-fast) var(--ak-ease-standard);
 }
 
-:where([data-slot="table-row"]:hover) {
-  background: var(--ak-color-hover);
+:where(
+  [data-slot="table-row"]:hover,
+  [data-slot="table-row"][aria-expanded="true"],
+  [data-slot="table-row"][data-state="selected"]
+) {
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
 }
 
 :where([data-slot="table-header-cell"]),
 :where([data-slot="table-cell"]) {
-  padding: var(--ak-space-sm);
-  border-block-end: 1px solid var(--ak-color-border);
+  padding: var(--ak-space-sm) var(--ak-space-xs);
   color: var(--ak-color-text);
   font-size: var(--ak-font-size-sm);
   line-height: var(--ak-line-height-normal);
   text-align: start;
-  vertical-align: top;
-  overflow-wrap: anywhere;
+  vertical-align: middle;
+  white-space: normal;
 }
 
-:where([data-slot="table-body"] [data-slot="table-row"]:last-child [data-slot="table-cell"]) {
+:where([data-slot="table-body"] [data-slot="table-row"]:last-child),
+:where([data-slot="table-foot"] [data-slot="table-row"]:last-child) {
   border-block-end: 0;
 }
 
 :where([data-slot="table-header-cell"]) {
-  color: var(--ak-color-text-muted);
-  font-weight: var(--ak-font-weight-semibold);
-  letter-spacing: 0;
-  overflow-wrap: normal;
-  text-transform: none;
-  word-break: normal;
-  white-space: normal;
+  block-size: 2.5rem;
+  font-weight: var(--ak-font-weight-medium);
 }
 
 :where([data-slot="table-cell"]) {
   font-weight: var(--ak-font-weight-regular);
 }
 
-@media (max-width: 30rem) {
-  :where([data-slot="table-header-cell"]),
-  :where([data-slot="table-cell"]) {
-    padding: var(--ak-space-sm) var(--ak-space-xs);
-    font-size: var(--ak-font-size-xs);
-    line-height: var(--ak-line-height-tight);
-  }
+:where(
+  [data-slot="table-header-cell"]:has([role="checkbox"]),
+  [data-slot="table-cell"]:has([role="checkbox"])
+) {
+  padding-inline-end: 0;
+}
 
-  :where([data-slot="table-header-cell"]) {
-    letter-spacing: 0;
-    overflow-wrap: anywhere;
-  }
+:where(
+  [data-slot="table-header-cell"] > [role="checkbox"],
+  [data-slot="table-cell"] > [role="checkbox"]
+) {
+  transform: translateY(2px);
 }

--- a/src/themes/default/styles/display/virtual-table.css
+++ b/src/themes/default/styles/display/virtual-table.css
@@ -30,11 +30,11 @@
 }
 
 :where([data-slot="virtual-table-head"]) {
-  background: var(--ak-color-surface-muted);
+  background: var(--ak-color-surface);
 }
 
 :where([data-slot="virtual-table-header-row"]) {
-  background: inherit;
+  background: var(--ak-color-surface);
 }
 
 :where([data-slot="virtual-table-body"]) {
@@ -42,7 +42,7 @@
 }
 
 :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
-  padding: var(--ak-space-sm);
+  padding: var(--ak-space-sm) var(--ak-space-xs);
   border-block-end: 1px solid var(--ak-color-border);
   color: var(--ak-color-text);
   font-size: var(--ak-font-size-sm);
@@ -55,10 +55,8 @@
 }
 
 :where([data-slot="virtual-table-header-cell"]) {
-  color: var(--ak-color-text-muted);
-  font-weight: var(--ak-font-weight-semibold);
-  letter-spacing: 0;
-  text-transform: none;
+  block-size: 2.5rem;
+  font-weight: var(--ak-font-weight-medium);
 }
 
 :where([data-slot="virtual-table-row"]) {
@@ -69,11 +67,11 @@
 }
 
 :where([data-slot="virtual-table-row"]:hover) {
-  background: var(--ak-color-hover);
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
 }
 
 :where([data-slot="virtual-table-row"][data-selected="true"]) {
-  background: var(--ak-color-selected);
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
   color: var(--ak-color-text);
 }
 
@@ -85,6 +83,20 @@
   display: flex;
   align-items: center;
   min-inline-size: 0;
+}
+
+:where(
+  [data-slot="virtual-table-header-cell"]:has([role="checkbox"]),
+  [data-slot="virtual-table-cell"]:has([role="checkbox"])
+) {
+  padding-inline-end: 0;
+}
+
+:where(
+  [data-slot="virtual-table-header-cell"] > [role="checkbox"],
+  [data-slot="virtual-table-cell"] > [role="checkbox"]
+) {
+  transform: translateY(2px);
 }
 
 @media (max-width: 30rem) {

--- a/templates/theme/styles/base/reset.css
+++ b/templates/theme/styles/base/reset.css
@@ -22,6 +22,10 @@
   display: block;
 }
 
+:where([data-askr-native-control="true"]) {
+  font: inherit;
+}
+
 ::selection {
   background: color-mix(in srgb, var(--ak-color-primary-soft) 84%, transparent);
   color: var(--ak-color-text);

--- a/templates/theme/styles/display/table.css
+++ b/templates/theme/styles/display/table.css
@@ -3,13 +3,12 @@
   min-inline-size: 0;
   border-collapse: collapse;
   border-spacing: 0;
-  table-layout: fixed;
+  table-layout: auto;
   border: 0;
   border-radius: 0;
   background: transparent;
   color: var(--ak-color-text);
   box-shadow: none;
-  overflow: hidden;
 }
 
 :where([data-slot="data-table"]) {
@@ -19,16 +18,16 @@
 }
 
 :where([data-slot="table-caption"]) {
-  padding: 0 0 var(--ak-space-sm);
+  padding-block-start: var(--ak-space-md);
   color: var(--ak-color-text-muted);
   font-size: var(--ak-font-size-sm);
   line-height: var(--ak-line-height-normal);
   text-align: start;
-  caption-side: top;
+  caption-side: bottom;
 }
 
 :where([data-slot="table-head"]) {
-  background: var(--ak-color-surface-muted);
+  background: transparent;
 }
 
 :where([data-slot="table-body"]) {
@@ -36,58 +35,60 @@
 }
 
 :where([data-slot="table-foot"]) {
-  background: transparent;
+  border-block-start: 1px solid var(--ak-color-border);
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
+  font-weight: var(--ak-font-weight-medium);
 }
 
 :where([data-slot="table-row"]) {
   background: inherit;
+  border-block-end: 1px solid var(--ak-color-border);
   transition: background var(--ak-duration-fast) var(--ak-ease-standard);
 }
 
-:where([data-slot="table-row"]:hover) {
-  background: var(--ak-color-hover);
+:where(
+  [data-slot="table-row"]:hover,
+  [data-slot="table-row"][aria-expanded="true"],
+  [data-slot="table-row"][data-state="selected"]
+) {
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
 }
 
 :where([data-slot="table-header-cell"]),
 :where([data-slot="table-cell"]) {
-  padding: var(--ak-space-sm);
-  border-block-end: 1px solid var(--ak-color-border);
+  padding: var(--ak-space-sm) var(--ak-space-xs);
   color: var(--ak-color-text);
   font-size: var(--ak-font-size-sm);
   line-height: var(--ak-line-height-normal);
   text-align: start;
-  vertical-align: top;
-  overflow-wrap: anywhere;
+  vertical-align: middle;
+  white-space: normal;
 }
 
-:where([data-slot="table-body"] [data-slot="table-row"]:last-child [data-slot="table-cell"]) {
+:where([data-slot="table-body"] [data-slot="table-row"]:last-child),
+:where([data-slot="table-foot"] [data-slot="table-row"]:last-child) {
   border-block-end: 0;
 }
 
 :where([data-slot="table-header-cell"]) {
-  color: var(--ak-color-text-muted);
-  font-weight: var(--ak-font-weight-semibold);
-  letter-spacing: 0;
-  overflow-wrap: normal;
-  text-transform: none;
-  word-break: normal;
-  white-space: normal;
+  block-size: 2.5rem;
+  font-weight: var(--ak-font-weight-medium);
 }
 
 :where([data-slot="table-cell"]) {
   font-weight: var(--ak-font-weight-regular);
 }
 
-@media (max-width: 30rem) {
-  :where([data-slot="table-header-cell"]),
-  :where([data-slot="table-cell"]) {
-    padding: var(--ak-space-sm) var(--ak-space-xs);
-    font-size: var(--ak-font-size-xs);
-    line-height: var(--ak-line-height-tight);
-  }
+:where(
+  [data-slot="table-header-cell"]:has([role="checkbox"]),
+  [data-slot="table-cell"]:has([role="checkbox"])
+) {
+  padding-inline-end: 0;
+}
 
-  :where([data-slot="table-header-cell"]) {
-    letter-spacing: 0;
-    overflow-wrap: anywhere;
-  }
+:where(
+  [data-slot="table-header-cell"] > [role="checkbox"],
+  [data-slot="table-cell"] > [role="checkbox"]
+) {
+  transform: translateY(2px);
 }

--- a/templates/theme/styles/display/virtual-table.css
+++ b/templates/theme/styles/display/virtual-table.css
@@ -30,11 +30,11 @@
 }
 
 :where([data-slot="virtual-table-head"]) {
-  background: var(--ak-color-surface-muted);
+  background: var(--ak-color-surface);
 }
 
 :where([data-slot="virtual-table-header-row"]) {
-  background: inherit;
+  background: var(--ak-color-surface);
 }
 
 :where([data-slot="virtual-table-body"]) {
@@ -42,7 +42,7 @@
 }
 
 :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
-  padding: var(--ak-space-sm);
+  padding: var(--ak-space-sm) var(--ak-space-xs);
   border-block-end: 1px solid var(--ak-color-border);
   color: var(--ak-color-text);
   font-size: var(--ak-font-size-sm);
@@ -55,10 +55,8 @@
 }
 
 :where([data-slot="virtual-table-header-cell"]) {
-  color: var(--ak-color-text-muted);
-  font-weight: var(--ak-font-weight-semibold);
-  letter-spacing: 0;
-  text-transform: none;
+  block-size: 2.5rem;
+  font-weight: var(--ak-font-weight-medium);
 }
 
 :where([data-slot="virtual-table-row"]) {
@@ -69,16 +67,30 @@
 }
 
 :where([data-slot="virtual-table-row"]:hover) {
-  background: var(--ak-color-hover);
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
 }
 
 :where([data-slot="virtual-table-row"][data-selected="true"]) {
-  background: var(--ak-color-selected);
+  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
   color: var(--ak-color-text);
 }
 
 :where([data-slot="virtual-table-spacer-row"]) {
   background: transparent;
+}
+
+:where(
+  [data-slot="virtual-table-header-cell"]:has([role="checkbox"]),
+  [data-slot="virtual-table-cell"]:has([role="checkbox"])
+) {
+  padding-inline-end: 0;
+}
+
+:where(
+  [data-slot="virtual-table-header-cell"] > [role="checkbox"],
+  [data-slot="virtual-table-cell"] > [role="checkbox"]
+) {
+  transform: translateY(2px);
 }
 
 @media (max-width: 30rem) {

--- a/tests/browser/aria-role-audit.test.tsx
+++ b/tests/browser/aria-role-audit.test.tsx
@@ -1,0 +1,127 @@
+import axe from "axe-core";
+import { cleanupApp, createSPA } from "@askrjs/askr/boot";
+import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import {
+  Alert,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  ButtonGroup,
+  CalendarBody,
+  CalendarCell,
+  CalendarDay,
+  CalendarGrid,
+  CalendarRow,
+  Combobox,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxOption,
+  Command,
+  CommandItem,
+  CommandList,
+  FieldError,
+  InputGroup,
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  Separator,
+  Spinner,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "../../src/components";
+import { createTestRegistry, resetTestRoutes, testRoute } from "../router-test-utils";
+
+describe("ARIA and role audit", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    resetTestRoutes();
+    window.history.replaceState({}, "", "/aria-role-audit");
+  });
+
+  afterEach(() => {
+    cleanupApp(container);
+    container.remove();
+    resetTestRoutes();
+  });
+
+  it("should not emit incomplete interactive ARIA patterns from styling-only components", async () => {
+    testRoute("/aria-role-audit", () => (
+      <main>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">Home</BreadcrumbLink>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+        <Pagination>
+          <PaginationContent>
+            <PaginationItem>
+              <PaginationLink href="/page/1" active>
+                1
+              </PaginationLink>
+            </PaginationItem>
+          </PaginationContent>
+        </Pagination>
+        <Alert title="Notice" description="Saved" />
+        <ButtonGroup aria-label="Document actions">
+          <button type="button">Save</button>
+        </ButtonGroup>
+        <InputGroup aria-label="Amount">
+          <input aria-label="Amount" />
+        </InputGroup>
+        <FieldError>Amount is required</FieldError>
+        <Separator />
+        <Spinner />
+        <CalendarGrid>
+          <CalendarBody>
+            <CalendarRow>
+              <CalendarCell>
+                <CalendarDay selected>1</CalendarDay>
+              </CalendarCell>
+            </CalendarRow>
+          </CalendarBody>
+        </CalendarGrid>
+        <Combobox>
+          <ComboboxInput aria-label="Project" />
+          <ComboboxList>
+            <ComboboxOption>Askr</ComboboxOption>
+          </ComboboxList>
+        </Combobox>
+        <Command>
+          <CommandList>
+            <CommandItem selected>Open</CommandItem>
+          </CommandList>
+        </Command>
+        <ResizablePanelGroup>
+          <ResizablePanel>First</ResizablePanel>
+          <ResizableHandle />
+          <ResizablePanel>Second</ResizablePanel>
+        </ResizablePanelGroup>
+        <TabsList>
+          <TabsTrigger>Preview</TabsTrigger>
+        </TabsList>
+        <TabsContent>Panel</TabsContent>
+      </main>
+    ));
+
+    await createSPA({ root: container, registry: createTestRegistry() });
+    const results = await axe.run(container, { rules: { "color-contrast": { enabled: false } } });
+
+    expect(
+      results.violations.map((violation) => ({
+        id: violation.id,
+        targets: violation.nodes.map((node) => node.target.join(" ")),
+      })),
+    ).toEqual([]);
+  });
+});

--- a/tests/browser/responsive-visual-contracts.test.tsx
+++ b/tests/browser/responsive-visual-contracts.test.tsx
@@ -134,7 +134,7 @@ describe("responsive and visual theme contracts", () => {
     await page.viewport(390, 844);
     window.history.replaceState({}, "", "/narrow-table");
     testRoute("/narrow-table", () => (
-      <div class="table-width" style="width:320px">
+      <div class="table-width" style="width:320px;overflow-x:auto">
         <Table aria-label="Deployments">
           <TableHead>
             <TableRow>
@@ -162,12 +162,10 @@ describe("responsive and visual theme contracts", () => {
     const heading = container.querySelector<HTMLElement>('[data-slot="table-header-cell"]')!;
     const cell = container.querySelector<HTMLElement>('[data-slot="table-cell"]')!;
 
-    expect(getComputedStyle(table).tableLayout).toBe("fixed");
-    expect(table.getBoundingClientRect().width).toBeLessThanOrEqual(
-      wrapper.getBoundingClientRect().width,
-    );
-    expect(getComputedStyle(heading).overflowWrap).toBe("anywhere");
-    expect(getComputedStyle(cell).overflowWrap).toBe("anywhere");
+    expect(getComputedStyle(table).tableLayout).toBe("auto");
+    expect(getComputedStyle(wrapper).overflowX).toBe("auto");
+    expect(getComputedStyle(heading).whiteSpace).toBe("normal");
+    expect(getComputedStyle(cell).whiteSpace).toBe("normal");
   });
 
   it("should layer and focus a dropdown opened from a dialog inside a sidebar", async () => {

--- a/tests/browser/table-theme.test.tsx
+++ b/tests/browser/table-theme.test.tsx
@@ -5,7 +5,9 @@ import { cleanupApp, createSPA } from "@askrjs/askr/boot";
 import {
   Table,
   TableBody,
+  TableCaption,
   TableCell,
+  TableFoot,
   TableHead,
   TableHeaderCell,
   TableRow,
@@ -41,6 +43,7 @@ describe("table theme smoke test", () => {
   it("should style the semantic table primitives through the default theme bundle", async () => {
     testRoute("/table", () => (
       <Table aria-label="Users">
+        <TableCaption>Current users</TableCaption>
         <TableHead>
           <TableRow>
             <TableHeaderCell>Name</TableHeaderCell>
@@ -48,11 +51,17 @@ describe("table theme smoke test", () => {
           </TableRow>
         </TableHead>
         <TableBody>
-          <TableRow>
+          <TableRow data-state="selected">
             <TableCell>Alice</TableCell>
             <TableCell>alice@example.com</TableCell>
           </TableRow>
         </TableBody>
+        <TableFoot>
+          <TableRow>
+            <TableCell>Total</TableCell>
+            <TableCell>1 user</TableCell>
+          </TableRow>
+        </TableFoot>
       </Table>
     ));
 
@@ -66,11 +75,27 @@ describe("table theme smoke test", () => {
     const bodyCell = container?.querySelector(
       '[data-slot="table-cell"]',
     ) as HTMLTableCellElement | null;
+    const caption = container?.querySelector(
+      '[data-slot="table-caption"]',
+    ) as HTMLTableCaptionElement | null;
+    const selectedRow = container?.querySelector(
+      '[data-slot="table-row"][data-state="selected"]',
+    ) as HTMLTableRowElement | null;
+    const footer = container?.querySelector(
+      '[data-slot="table-foot"]',
+    ) as HTMLTableSectionElement | null;
 
     expect(table?.getAttribute("data-slot")).toBe("table");
     expect(headerCell?.getAttribute("data-slot")).toBe("table-header-cell");
     expect(bodyCell?.getAttribute("data-slot")).toBe("table-cell");
     expect(getComputedStyle(table!).borderCollapse).toBe("collapse");
+    expect(getComputedStyle(table!).tableLayout).toBe("auto");
+    expect(getComputedStyle(caption!).captionSide).toBe("bottom");
+    expect(getComputedStyle(headerCell!).verticalAlign).toBe("middle");
+    expect(getComputedStyle(headerCell!).whiteSpace).toBe("normal");
+    expect(getComputedStyle(bodyCell!).verticalAlign).toBe("middle");
+    expect(getComputedStyle(selectedRow!).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(footer!).fontWeight).not.toBe("400");
     expect(getComputedStyle(bodyCell!).paddingInlineStart).not.toBe("0px");
   });
 });

--- a/tests/browser/visual-polish.test.tsx
+++ b/tests/browser/visual-polish.test.tsx
@@ -166,13 +166,7 @@ describe("visual polish contracts", () => {
     );
 
     for (const header of tableHeaders) {
-      const expectedHeaderWrap = window.matchMedia("(max-width: 30rem)").matches
-        ? "anywhere"
-        : "normal";
-      expect(getComputedStyle(header).overflowWrap, header.textContent ?? "").toBe(
-        expectedHeaderWrap,
-      );
-      expect(header.scrollWidth, header.textContent ?? "").toBeLessThanOrEqual(header.clientWidth);
+      expect(getComputedStyle(header).whiteSpace, header.textContent ?? "").toBe("normal");
     }
   });
 
@@ -340,6 +334,7 @@ describe("visual polish contracts", () => {
     const headerCell = wrapper.querySelector(
       '[data-slot="virtual-table-header-cell"]',
     ) as HTMLElement;
+    const tableHead = wrapper.querySelector('[data-slot="virtual-table-head"]') as HTMLElement;
     const selectedRow = wrapper.querySelector(
       '[data-slot="virtual-table-row"][data-selected="true"]',
     ) as HTMLElement;
@@ -363,6 +358,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(tableInner).borderCollapse).toBe("collapse");
     expect(px(getComputedStyle(tableInner).minWidth)).toBe(640);
     expect(getComputedStyle(headerCell).fontWeight).not.toBe("400");
+    expect(getComputedStyle(tableHead).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(getComputedStyle(selectedRow).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(getComputedStyle(tableCell).textOverflow).toBe("ellipsis");
     expect(getComputedStyle(monoText).fontVariantNumeric).toContain("tabular-nums");
@@ -516,6 +512,7 @@ describe("visual polish contracts", () => {
       const overflowing = [...doc.querySelectorAll("body *")]
         .filter((el) => {
           const htmlEl = el as HTMLElement;
+          if (htmlEl.closest(".compact-table-wrap")) return false;
           const bounds = htmlEl.getBoundingClientRect();
           return bounds.left < -2 || bounds.right > root.clientWidth + 2;
         })
@@ -585,10 +582,11 @@ describe("visual polish contracts", () => {
     const headerCell = table.querySelector('[data-slot="table-header-cell"]') as HTMLElement;
     const bodyCell = table.querySelector('[data-slot="table-cell"]') as HTMLElement;
 
-    expect(getComputedStyle(table).tableLayout).toBe("fixed");
-    expect(table.scrollWidth).toBeLessThanOrEqual(table.clientWidth + 4);
-    expect(headerCell.scrollWidth).toBeLessThanOrEqual(headerCell.clientWidth);
-    expect(bodyCell.scrollWidth).toBeLessThanOrEqual(bodyCell.clientWidth);
+    expect(getComputedStyle(table).tableLayout).toBe("auto");
+    expect(getComputedStyle(headerCell).whiteSpace).toBe("normal");
+    expect(getComputedStyle(bodyCell).whiteSpace).toBe("normal");
+    expect(getComputedStyle(headerCell).verticalAlign).toBe("middle");
+    expect(getComputedStyle(bodyCell).verticalAlign).toBe("middle");
     expect(px(getComputedStyle(headerCell).paddingInlineStart)).toBeLessThanOrEqual(8);
     expect(getComputedStyle(headerCell).letterSpacing).toBe("normal");
   });

--- a/tests/installed-types.js
+++ b/tests/installed-types.js
@@ -67,7 +67,7 @@ try {
       'const paletteContent: CommandPaletteContentProps = { title: "Search docs" };',
       'const block: BlockProps = { padding: "md", wrap: { base: true, md: false } };',
       "const wrapped = <Block wrap><span>wrapped</span></Block>;",
-      'const legacy = <><Box padding="4" /><Stack gap="2" /><Inline wrap /></>;',
+      'const legacy = <><Box padding="4" wrap="wrap" /><Stack gap="2" wrap={{ base: "nowrap", md: "wrap" }} /><Inline wrap="nowrap" /></>;',
       'const legacyProps: LegacyLayoutProps = { minWidth: "sm", class: "legacy", style: { color: "red" }, "aria-label": "Legacy", "data-project": "example", onClick: () => {} };',
       "const typedLegacy = Box(legacyProps);",
       "// @ts-expect-error wrap accepts only booleans or responsive booleans",

--- a/tests/unit/components-entrypoint.test.ts
+++ b/tests/unit/components-entrypoint.test.ts
@@ -14,6 +14,7 @@ import {
   BrandMark,
   Calendar,
   CalendarDay,
+  CalendarGrid,
   CalendarHeader,
   Card,
   CardContent,
@@ -22,10 +23,14 @@ import {
   Carousel,
   Checkbox,
   Combobox,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxOption,
   Command,
   CommandPalette,
   CommandGroupHeading,
   CommandItem,
+  CommandList,
   DataTable,
   DatePicker,
   Dialog,
@@ -47,6 +52,7 @@ import {
   Pagination,
   Popover,
   ResizablePanelGroup,
+  ResizableHandle,
   Select,
   Sheet,
   SheetContent,
@@ -173,7 +179,7 @@ describe("components entrypoint", () => {
       "command-group-heading",
     );
     expect(
-      asElement(CommandItem({ children: "Calendar", selected: true })).props["aria-selected"],
+      asElement(CommandItem({ children: "Calendar", selected: true })).props["data-selected"],
     ).toBe("true");
     expect(
       asElement(ItemGroup({ children: ItemHeader({ children: "Header" }) })).props["data-slot"],
@@ -251,5 +257,23 @@ describe("components entrypoint", () => {
     expect(text.props["data-numeric"]).toBe("tabular");
     expect(text.props["data-wrap"]).toBe("anywhere");
     expect(text.props["data-truncate"]).toBe("true");
+  });
+
+  it("should leave behavior-owned roles off styling-only compatibility anatomy", () => {
+    for (const component of [
+      CalendarGrid({}),
+      ComboboxInput({}),
+      ComboboxList({}),
+      ComboboxOption({}),
+      CommandList({}),
+      CommandItem({}),
+      ResizableHandle({}),
+      TabsList({}),
+      TabsContent({}),
+    ]) {
+      expect(asElement(component).props.role).toBeUndefined();
+    }
+
+    expect(asElement(TabsList({ role: "tablist" })).props.role).toBe("tablist");
   });
 });

--- a/tests/unit/legacy-layout-compatibility.test.ts
+++ b/tests/unit/legacy-layout-compatibility.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+type ElementLike = {
+  props: Record<string, unknown>;
+};
+
+function asElement(value: unknown): ElementLike {
+  return value as ElementLike;
+}
+
+describe("legacy layout compatibility", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should normalize legacy wrap strings like their boolean equivalents", async () => {
+    vi.resetModules();
+    const { Inline, Stack } = await import("../../src/components/catalog");
+
+    expect(asElement(Inline({ wrap: "wrap" })).props.class).toBe(
+      asElement(Inline({ wrap: true })).props.class,
+    );
+    expect(asElement(Inline({ wrap: "nowrap" })).props.class).toBe(
+      asElement(Inline({ wrap: false })).props.class,
+    );
+    expect(asElement(Stack({ wrap: { base: "nowrap", md: "wrap" } })).props.class).toBe(
+      asElement(Stack({ wrap: { base: false, md: true } })).props.class,
+    );
+  });
+
+  it("should warn once per deprecated component with its replacement", async () => {
+    vi.resetModules();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { Box, Inline, Shell, ShellMain, ShellNav, Stack } =
+      await import("../../src/components/catalog");
+
+    Box({});
+    Box({});
+    Stack({});
+    Inline({});
+    Shell({});
+    ShellNav({});
+    ShellMain({});
+
+    expect(warn).toHaveBeenCalledTimes(6);
+    expect(warn.mock.calls.map(([message]) => String(message))).toEqual([
+      "[askr-themes] Box is deprecated. Use Block directly.",
+      '[askr-themes] Stack is deprecated. Use <Block direction="column">.',
+      '[askr-themes] Inline is deprecated. Use <Block direction="row">.',
+      "[askr-themes] Shell is deprecated. Compose semantic Block primitives instead.",
+      '[askr-themes] ShellNav is deprecated. Use <Block as="nav">.',
+      '[askr-themes] ShellMain is deprecated. Use <Block as="main" grow>.',
+    ]);
+  });
+});

--- a/tests/unit/source-style-contract.test.ts
+++ b/tests/unit/source-style-contract.test.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vite-plus/test";
+
+function sourceFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const candidate = path.join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(candidate);
+    return entry.isFile() && /\.(ts|tsx)$/.test(entry.name) ? [candidate] : [];
+  });
+}
+
+describe("Component style contract", () => {
+  it("should not emit or mutate inline styles", () => {
+    const components = path.resolve(__dirname, "../../src/components");
+    const violations = sourceFiles(components).flatMap((file) => {
+      const relative = path.relative(components, file);
+      return fs
+        .readFileSync(file, "utf8")
+        .split(/\r?\n/)
+        .flatMap((line, index) =>
+          /\bstyle\s*=(?!=)|\.style\.[A-Za-z_$][\w$]*\s*=|\.style\.setProperty\s*\(|setAttribute\(\s*["']style["']/.test(
+            line,
+          )
+            ? [`${relative}:${index + 1}: ${line.trim()}`]
+            : [],
+        );
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/visual-quality-contract.test.ts
+++ b/tests/unit/visual-quality-contract.test.ts
@@ -2,7 +2,13 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vite-plus/test";
 
-import { DOCS_DIR, DEFAULT_THEME_STYLES_DIR, ROOT_DIR, THEMING_FILE } from "./test-paths";
+import {
+  DOCS_DIR,
+  DEFAULT_THEME_STYLES_DIR,
+  ROOT_DIR,
+  TEMPLATE_THEME_STYLES_DIR,
+  THEMING_FILE,
+} from "./test-paths";
 
 const VISUAL_CHECK_FILE = join(ROOT_DIR, "visual-check.html");
 const DOCS_README_FILE = join(DOCS_DIR, "README.md");
@@ -13,12 +19,15 @@ const INPUT_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "forms", "input.css");
 const CARD_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "card.css");
 const CATALOG_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "catalog.css");
 const TABLE_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "table.css");
+const VIRTUAL_TABLE_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "virtual-table.css");
 const BLOCK_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "layout", "block.css");
 const HEADER_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "shell", "header.css");
 const NAVBAR_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "shell", "navbar.css");
 const DROPDOWN_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "overlays", "dropdown.css");
 const TOOLTIP_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "overlays", "tooltip.css");
 const ACCESSIBILITY_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "base", "accessibility.css");
+const RESET_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "base", "reset.css");
+const TEMPLATE_RESET_CSS_FILE = join(TEMPLATE_THEME_STYLES_DIR, "base", "reset.css");
 
 function read(path: string): string {
   return readFileSync(path, "utf8");
@@ -35,11 +44,21 @@ describe("visual quality contract", () => {
   const cardCss = read(CARD_CSS_FILE);
   const catalogCss = read(CATALOG_CSS_FILE);
   const tableCss = read(TABLE_CSS_FILE);
+  const virtualTableCss = read(VIRTUAL_TABLE_CSS_FILE);
   const blockCss = read(BLOCK_CSS_FILE);
   const headerCss = read(HEADER_CSS_FILE);
   const navbarCss = read(NAVBAR_CSS_FILE);
   const dropdownCss = read(DROPDOWN_CSS_FILE);
   const tooltipCss = read(TOOLTIP_CSS_FILE);
+
+  it("should ship native-control typography through default and template foundations", () => {
+    const expected = ':where([data-askr-native-control="true"])';
+
+    expect(read(RESET_CSS_FILE)).toContain(expected);
+    expect(read(RESET_CSS_FILE)).toContain("font: inherit;");
+    expect(read(TEMPLATE_RESET_CSS_FILE)).toContain(expected);
+    expect(read(TEMPLATE_RESET_CSS_FILE)).toContain("font: inherit;");
+  });
 
   it("should keep the manual audit page broad enough for polish work", () => {
     const requiredAuditCopy = [
@@ -184,7 +203,18 @@ describe("visual quality contract", () => {
     expect(catalogCss).toContain("inline-size: 2rem;");
 
     expect(tableCss).toContain('[data-slot="data-table"]');
-    expect(tableCss).toContain("background: var(--ak-color-surface-muted);");
+    expect(tableCss).toContain("table-layout: auto;");
+    expect(tableCss).toContain("caption-side: bottom;");
+    expect(tableCss).toContain('[data-state="selected"]');
+    expect(tableCss).toContain('[role="checkbox"]');
+    expect(tableCss).toContain("vertical-align: middle;");
+    expect(tableCss).toContain("white-space: normal;");
+    expect(tableCss).toContain("background: color-mix(");
     expect(tableCss).toContain('[data-slot="table-row"]:last-child');
+    expect(virtualTableCss).toContain("block-size: 2.5rem;");
+    expect(virtualTableCss).toContain("font-weight: var(--ak-font-weight-medium);");
+    expect(virtualTableCss).toContain("background: color-mix(");
+    expect(virtualTableCss).toContain('[role="checkbox"]');
+    expect(virtualTableCss).toContain("background: var(--ak-color-surface);");
   });
 });


### PR DESCRIPTION
## Summary

- audit catalog roles and accessible names with automated coverage
- enforce the no-inline-style contract and move native-control resets into shared foundations
- align semantic and virtual table styling while preserving narrow-screen wrapping and opaque sticky headers
- restore legacy layout compatibility and surface deprecated catalog components
- bump @askrjs/themes to 0.2.2

## Validation

- npm run check
- 29 unit files / 600 tests
- 11 jsdom files / 59 tests
- 63 browser files / 201 tests
- forced-colors, installed types, publint, package, and granular bundle checks

Closes #91
Closes #92