### PR TITLE
Fix virtual-table, Block, and dialog theme contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Unreleased
+
+- Corrected `Block` layout fallbacks so omitted properties now resolve to
+  their native CSS initial values. Existing consumers that unintentionally
+  relied on `Block` forcing column direction, stretched alignment, zero gap,
+  or a zero minimum width should pass the corresponding Block prop explicitly.
+- Stopped the generic `data-slot="block"` hook from inheriting the structural
+  components' defensive `min-inline-size: 0` rule; dedicated structural slots
+  retain that constraint.
+- Clarified that the shipped Dialog and AlertDialog overlays already provide
+  the default backdrop, blur, stacking, and animation treatment, and documented
+  token-level customization instead of competing overlay classes.

--- a/THEMING.md
+++ b/THEMING.md
@@ -568,7 +568,10 @@ Status badge:
 
 Dialog backdrop:
 
-- use `--ak-color-backdrop`
+- use the shipped `DialogOverlay` or `AlertDialogOverlay`; the default theme
+  already applies `--ak-color-backdrop`, blur, stacking, and animation
+- customize the theme-level values of `--ak-color-backdrop` and
+  `--ak-z-modal-backdrop` when the product needs a different backdrop
 
 ### Incorrect usage examples
 
@@ -579,6 +582,24 @@ Do not:
 - use border colors as text colors
 - derive component styling from unrelated tokens
 - invent one-off component colors inside `askr-ui`
+- replace the shipped dialog overlay treatment with a competing
+  `class`/`className` that sets `background` or `z-index` directly
+
+Dialog backdrop customization:
+
+```css
+/* Do: customize the shared theme contract. */
+:root {
+  --ak-color-backdrop: rgb(8 12 20 / 18%);
+  --ak-z-modal-backdrop: 1040;
+}
+
+/* Do not: bypass the shipped overlay treatment. */
+.dialog-overlay {
+  background: rgb(0 0 0 / 90%);
+  z-index: 9999;
+}
+```
 
 ---
 

--- a/docs/component-anatomy.md
+++ b/docs/component-anatomy.md
@@ -23,7 +23,13 @@ own a focused visual job.
 
 `Block` renders one element, defaults to `div`, and always emits
 `data-ak-layout="true"`. If no slot is provided, it emits `data-slot="block"`.
-Semantic wrappers use their own slots.
+Semantic wrappers use their own slots. `Block` uses `display: flex` as its
+documented layout-engine default. Every other layout fallback matches the
+theme baseline for a plain element (including the global border-box reset), so
+an author class can provide only the properties it needs without an omitted
+property silently changing behavior.
+Passing a Block prop, including a responsive value, explicitly overrides that
+property through the generated custom-property contract.
 
 | Component    | Shape                                                                       | Stable slots                                                                                                                    | Style here                                                                                                      | Avoid                                                                   |
 | ------------ | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
@@ -59,8 +65,8 @@ Prefer the layout prop when the wrapping belongs to `Block` itself:
 </Block>
 ```
 
-`wrap` defaults to `false` (`nowrap`). User styles retain their normal
-precedence over generated layout declarations.
+`wrap` follows the CSS initial value (`nowrap`) when omitted. User styles retain
+their normal precedence over generated layout declarations.
 
 ## Legacy layout aliases
 

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -134,9 +134,16 @@ export function NavGroup(props: NavGroupProps): JSX.Element {
   const { align, children, label, title = label, ...rest } = props;
 
   return (
-    <LayoutBlock align={align} gap="sm" {...rest} data-align={align} data-slot="nav-group">
+    <LayoutBlock
+      direction="column"
+      align={align}
+      gap="sm"
+      {...rest}
+      data-align={align}
+      data-slot="nav-group"
+    >
       {title !== undefined ? <div data-slot="nav-group-label">{title}</div> : null}
-      <LayoutBlock gap="xs" data-slot="nav-group-body">
+      <LayoutBlock direction="column" gap="xs" data-slot="nav-group-body">
         {children}
       </LayoutBlock>
     </LayoutBlock>

--- a/src/themes/default/styles/display/virtual-table.css
+++ b/src/themes/default/styles/display/virtual-table.css
@@ -9,6 +9,9 @@
   overscroll-behavior: contain;
   scrollbar-width: thin;
   scrollbar-color: var(--ak-color-border-strong) transparent;
+  transition:
+    border-color var(--ak-duration-fast) var(--ak-ease-standard),
+    box-shadow var(--ak-duration-fast) var(--ak-ease-standard);
 }
 
 :where([data-slot="virtual-table"][data-viewport="lg"]) {
@@ -30,11 +33,18 @@
 }
 
 :where([data-slot="virtual-table-head"]) {
-  background: var(--ak-color-surface);
+  background: var(--ak-color-surface-muted);
+  box-shadow: inset 0 -1px 0 var(--ak-color-border);
 }
 
 :where([data-slot="virtual-table-header-row"]) {
-  background: var(--ak-color-surface);
+  background: inherit;
+}
+
+:where([data-slot="virtual-table"][data-at-top="false"]) :where([data-slot="virtual-table-head"]) {
+  box-shadow:
+    inset 0 -1px 0 var(--ak-color-border),
+    var(--ak-shadow-md);
 }
 
 :where([data-slot="virtual-table-body"]) {
@@ -42,37 +52,73 @@
 }
 
 :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
-  padding: var(--ak-space-sm) var(--ak-space-xs);
-  border-block-end: 1px solid var(--ak-color-border);
-  color: var(--ak-color-text);
   font-size: var(--ak-font-size-sm);
   line-height: var(--ak-line-height-normal);
   text-align: start;
   vertical-align: middle;
+}
+
+:where([data-slot="virtual-table-header-cell"]) {
+  padding: 0 var(--ak-space-sm);
+  background: inherit;
+  color: var(--ak-color-text-muted);
+  font-weight: var(--ak-font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-:where([data-slot="virtual-table-header-cell"]) {
-  block-size: 2.5rem;
-  font-weight: var(--ak-font-weight-medium);
+:where([data-slot="virtual-table-cell"]) {
+  position: relative;
+  padding: 0;
+  border-block-end: 1px solid var(--ak-color-border);
+  color: var(--ak-color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 :where([data-slot="virtual-table-row"]) {
   background: transparent;
+  cursor: pointer;
   transition:
     background var(--ak-duration-fast) var(--ak-ease-standard),
-    color var(--ak-duration-fast) var(--ak-ease-standard);
+    color var(--ak-duration-fast) var(--ak-ease-standard),
+    box-shadow var(--ak-duration-fast) var(--ak-ease-standard);
+}
+
+:where([data-slot="virtual-table-row"])
+  :where(
+    [data-slot="input"]:not(:disabled, [data-disabled], [aria-disabled="true"]),
+    [data-slot="textarea"]:not(:disabled, [data-disabled], [aria-disabled="true"]),
+    [contenteditable="true"],
+    [role="searchbox"],
+    [role="spinbutton"],
+    [role="textbox"]
+  ) {
+  cursor: text;
 }
 
 :where([data-slot="virtual-table-row"]:hover) {
-  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
+  background: var(--ak-color-hover);
 }
 
 :where([data-slot="virtual-table-row"][data-selected="true"]) {
-  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
+  background: var(--ak-color-selected);
   color: var(--ak-color-text);
+  box-shadow: inset 0 0 0 var(--ak-border-width-sm) var(--ak-color-selected-border);
+}
+
+:where(
+  [data-slot="virtual-table-row"][data-selected="true"]
+    > [data-slot="virtual-table-cell"]:first-child
+)::before {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  inline-size: var(--ak-border-width-md);
+  background: var(--ak-color-primary);
+  content: "";
 }
 
 :where([data-slot="virtual-table-spacer-row"]) {
@@ -82,27 +128,98 @@
 :where([data-slot="virtual-table-cell-content"]) {
   display: flex;
   align-items: center;
+  gap: var(--ak-space-xs);
+  inline-size: 100%;
+  block-size: 100%;
   min-inline-size: 0;
+  padding-inline: var(--ak-space-sm);
+  box-sizing: border-box;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(
+  [data-slot="virtual-table-cell-content"] > [data-slot="text"],
+  [data-slot="virtual-table-cell-content"] > [data-truncate="true"]
+) {
+  min-inline-size: 0;
+  max-inline-size: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 :where(
   [data-slot="virtual-table-header-cell"]:has([role="checkbox"]),
-  [data-slot="virtual-table-cell"]:has([role="checkbox"])
+  [data-slot="virtual-table-cell-content"]:has([role="checkbox"])
 ) {
   padding-inline-end: 0;
 }
 
-:where(
-  [data-slot="virtual-table-header-cell"] > [role="checkbox"],
-  [data-slot="virtual-table-cell"] > [role="checkbox"]
-) {
+:where([data-slot="virtual-table-header-cell"] > [role="checkbox"]) {
   transform: translateY(2px);
 }
 
-@media (max-width: 30rem) {
+:where(
+  [data-slot="virtual-table-body"]
+    > [data-slot="virtual-table-row"][data-terminal-row="true"]
+    > [data-slot="virtual-table-cell"]
+) {
+  border-block-end: 0;
+}
+
+:where([data-slot="virtual-table"]:focus-visible, [data-slot="virtual-table-table"]:focus-visible) {
+  outline: none;
+}
+
+:where(
+  [data-slot="virtual-table"]:focus-visible,
+  [data-slot="virtual-table"]:has([data-slot="virtual-table-table"]:focus-visible)
+) {
+  border-color: var(--ak-color-ring);
+  box-shadow: 0 0 0 var(--ak-focus-ring-width) var(--ak-color-focus-ring);
+}
+
+@media (forced-colors: active) {
+  :where([data-slot="virtual-table"]) {
+    border-color: CanvasText;
+  }
+
+  :where(
+    [data-slot="virtual-table"]:focus-visible,
+    [data-slot="virtual-table"]:has([data-slot="virtual-table-table"]:focus-visible)
+  ) {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+    box-shadow: none;
+  }
+
+  :where([data-slot="virtual-table-head"]) {
+    background: Canvas;
+    color: CanvasText;
+    box-shadow: inset 0 -1px 0 CanvasText;
+  }
+
   :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
-    padding: var(--ak-space-sm) var(--ak-space-xs);
-    font-size: var(--ak-font-size-xs);
-    line-height: var(--ak-line-height-tight);
+    border-color: CanvasText;
+  }
+
+  :where([data-slot="virtual-table-row"][data-selected="true"]) {
+    background: Highlight;
+    color: HighlightText;
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+    box-shadow: none;
+  }
+
+  :where([data-slot="virtual-table-row"][data-selected="true"] > [data-slot="virtual-table-cell"]) {
+    color: HighlightText;
+  }
+
+  :where(
+    [data-slot="virtual-table-row"][data-selected="true"]
+      > [data-slot="virtual-table-cell"]:first-child
+  )::before {
+    background: HighlightText;
   }
 }

--- a/src/themes/default/styles/layout/block.css
+++ b/src/themes/default/styles/layout/block.css
@@ -1,5 +1,4 @@
 :where(
-  [data-slot="block"],
   [data-slot="container"],
   [data-slot="header"],
   [data-slot="main"],

--- a/src/themes/default/styles/layout/layout.css
+++ b/src/themes/default/styles/layout/layout.css
@@ -4,24 +4,24 @@
   --ak-display-md: var(--ak-display-sm);
   --ak-display-lg: var(--ak-display-md);
   --ak-display-xl: var(--ak-display-lg);
-  --ak-flex-direction-base: column;
+  --ak-flex-direction-base: row;
   --ak-flex-direction-sm: var(--ak-flex-direction-base);
   --ak-flex-direction-md: var(--ak-flex-direction-sm);
   --ak-flex-direction-lg: var(--ak-flex-direction-md);
   --ak-flex-direction-xl: var(--ak-flex-direction-lg);
   --ak-flex-wrap-base: nowrap;
   --ak-flex-wrap-sm: var(--ak-flex-wrap-base);
-  --ak-align-items-base: stretch;
+  --ak-align-items-base: normal;
   --ak-align-items-sm: var(--ak-align-items-base);
   --ak-align-items-md: var(--ak-align-items-sm);
   --ak-align-items-lg: var(--ak-align-items-md);
   --ak-align-items-xl: var(--ak-align-items-lg);
-  --ak-justify-content-base: flex-start;
+  --ak-justify-content-base: normal;
   --ak-justify-content-sm: var(--ak-justify-content-base);
   --ak-justify-content-md: var(--ak-justify-content-sm);
   --ak-justify-content-lg: var(--ak-justify-content-md);
   --ak-justify-content-xl: var(--ak-justify-content-lg);
-  --ak-gap-base: 0;
+  --ak-gap-base: normal;
   --ak-gap-sm: var(--ak-gap-base);
   --ak-gap-md: var(--ak-gap-sm);
   --ak-gap-lg: var(--ak-gap-md);
@@ -40,7 +40,7 @@
   --ak-flex-basis-sm: var(--ak-flex-basis-base);
   --ak-flex-basis-md: var(--ak-flex-basis-sm);
   --ak-flex-basis-lg: var(--ak-flex-basis-md);
-  --ak-min-width-base: 0;
+  --ak-min-width-base: auto;
   --ak-min-width-sm: var(--ak-min-width-base);
   --ak-min-width-md: var(--ak-min-width-sm);
   --ak-min-width-lg: var(--ak-min-width-md);
@@ -120,7 +120,7 @@
   --ak-overflow-x-sm: var(--ak-overflow-x-base);
   --ak-overflow-y-base: var(--ak-overflow-base);
   --ak-overflow-y-sm: var(--ak-overflow-y-base);
-  --ak-border-base: 0 solid transparent;
+  --ak-border-base: medium none currentcolor;
   --ak-border-sm: var(--ak-border-base);
   --ak-border-md: var(--ak-border-sm);
   --ak-border-lg: var(--ak-border-md);
@@ -156,15 +156,15 @@
 
   box-sizing: border-box;
   display: var(--ak-display-base, flex);
-  flex-direction: var(--ak-flex-direction-base, column);
+  flex-direction: var(--ak-flex-direction-base, row);
   flex-wrap: var(--ak-flex-wrap-base, nowrap);
-  align-items: var(--ak-align-items-base, stretch);
-  justify-content: var(--ak-justify-content-base, flex-start);
-  gap: var(--ak-gap-base, 0);
+  align-items: var(--ak-align-items-base, normal);
+  justify-content: var(--ak-justify-content-base, normal);
+  gap: var(--ak-gap-base, normal);
   flex-grow: var(--ak-flex-grow-base, 0);
   flex-shrink: var(--ak-flex-shrink-base, 1);
   flex-basis: var(--ak-flex-basis-base, auto);
-  min-width: var(--ak-min-width-base, 0);
+  min-width: var(--ak-min-width-base, auto);
   max-width: var(--ak-max-width-base, none);
   width: var(--ak-width-base, auto);
   min-height: var(--ak-min-height-base, auto);
@@ -186,10 +186,10 @@
   overflow: var(--ak-overflow-base, visible);
   overflow-x: var(--ak-overflow-x-base, var(--ak-overflow-base, visible));
   overflow-y: var(--ak-overflow-y-base, var(--ak-overflow-base, visible));
-  border: var(--ak-border-base, 0 solid transparent);
-  border-top: var(--ak-border-top-base, var(--ak-border-base, 0 solid transparent));
-  border-bottom: var(--ak-border-bottom-base, var(--ak-border-base, 0 solid transparent));
-  border-right: var(--ak-border-right-base, var(--ak-border-base, 0 solid transparent));
+  border: var(--ak-border-base, medium none currentcolor);
+  border-top: var(--ak-border-top-base, var(--ak-border-base, medium none currentcolor));
+  border-bottom: var(--ak-border-bottom-base, var(--ak-border-base, medium none currentcolor));
+  border-right: var(--ak-border-right-base, var(--ak-border-base, medium none currentcolor));
   border-radius: var(--ak-border-radius-base, 0);
   background: var(--ak-background-base, transparent);
   box-shadow: var(--ak-box-shadow-base, none);
@@ -198,15 +198,15 @@
 @media (min-width: 40rem) {
   :where([data-ak-layout="true"]) {
     display: var(--ak-display-sm, var(--ak-display-base, flex));
-    flex-direction: var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column));
+    flex-direction: var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row));
     flex-wrap: var(--ak-flex-wrap-sm, var(--ak-flex-wrap-base, nowrap));
-    align-items: var(--ak-align-items-sm, var(--ak-align-items-base, stretch));
-    justify-content: var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start));
-    gap: var(--ak-gap-sm, var(--ak-gap-base, 0));
+    align-items: var(--ak-align-items-sm, var(--ak-align-items-base, normal));
+    justify-content: var(--ak-justify-content-sm, var(--ak-justify-content-base, normal));
+    gap: var(--ak-gap-sm, var(--ak-gap-base, normal));
     flex-grow: var(--ak-flex-grow-sm, var(--ak-flex-grow-base, 0));
     flex-shrink: var(--ak-flex-shrink-sm, var(--ak-flex-shrink-base, 1));
     flex-basis: var(--ak-flex-basis-sm, var(--ak-flex-basis-base, auto));
-    min-width: var(--ak-min-width-sm, var(--ak-min-width-base, 0));
+    min-width: var(--ak-min-width-sm, var(--ak-min-width-base, auto));
     max-width: var(--ak-max-width-sm, var(--ak-max-width-base, none));
     width: var(--ak-width-sm, var(--ak-width-base, auto));
     min-height: var(--ak-min-height-sm, var(--ak-min-height-base, auto));
@@ -234,18 +234,27 @@
       --ak-overflow-y-sm,
       var(--ak-overflow-y-base, var(--ak-overflow-sm, var(--ak-overflow-base, visible)))
     );
-    border: var(--ak-border-sm, var(--ak-border-base, 0 solid transparent));
+    border: var(--ak-border-sm, var(--ak-border-base, medium none currentcolor));
     border-top: var(
       --ak-border-top-sm,
-      var(--ak-border-top-base, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(
+        --ak-border-top-base,
+        var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+      )
     );
     border-bottom: var(
       --ak-border-bottom-sm,
-      var(--ak-border-bottom-base, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(
+        --ak-border-bottom-base,
+        var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+      )
     );
     border-right: var(
       --ak-border-right-sm,
-      var(--ak-border-right-base, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(
+        --ak-border-right-base,
+        var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+      )
     );
     border-radius: var(--ak-border-radius-sm, var(--ak-border-radius-base, 0));
     background: var(--ak-background-sm, var(--ak-background-base, transparent));
@@ -258,20 +267,20 @@
     display: var(--ak-display-md, var(--ak-display-sm, var(--ak-display-base, flex)));
     flex-direction: var(
       --ak-flex-direction-md,
-      var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column))
+      var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row))
     );
     align-items: var(
       --ak-align-items-md,
-      var(--ak-align-items-sm, var(--ak-align-items-base, stretch))
+      var(--ak-align-items-sm, var(--ak-align-items-base, normal))
     );
     justify-content: var(
       --ak-justify-content-md,
-      var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start))
+      var(--ak-justify-content-sm, var(--ak-justify-content-base, normal))
     );
-    gap: var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, 0)));
+    gap: var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, normal)));
     flex-grow: var(--ak-flex-grow-md, var(--ak-flex-grow-sm, var(--ak-flex-grow-base, 0)));
     flex-shrink: var(--ak-flex-shrink-md, var(--ak-flex-shrink-sm, var(--ak-flex-shrink-base, 1)));
-    min-width: var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, 0)));
+    min-width: var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, auto)));
     max-width: var(--ak-max-width-md, var(--ak-max-width-sm, var(--ak-max-width-base, none)));
     width: var(--ak-width-md, var(--ak-width-sm, var(--ak-width-base, auto)));
     min-height: var(--ak-min-height-md, var(--ak-min-height-sm, var(--ak-min-height-base, auto)));
@@ -298,14 +307,17 @@
     position: var(--ak-position-md, var(--ak-position-sm, var(--ak-position-base, static)));
     top: var(--ak-top-md, var(--ak-top-sm, var(--ak-top-base, auto)));
     z-index: var(--ak-z-index-md, var(--ak-z-index-sm, var(--ak-z-index-base, auto)));
-    border: var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)));
+    border: var(
+      --ak-border-md,
+      var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+    );
     border-top: var(
       --ak-border-top-md,
       var(
         --ak-border-top-sm,
         var(
           --ak-border-top-base,
-          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
         )
       )
     );
@@ -315,7 +327,7 @@
         --ak-border-bottom-sm,
         var(
           --ak-border-bottom-base,
-          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
         )
       )
     );
@@ -325,7 +337,7 @@
         --ak-border-right-sm,
         var(
           --ak-border-right-base,
-          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
         )
       )
     );
@@ -349,23 +361,20 @@
     );
     flex-direction: var(
       --ak-flex-direction-lg,
-      var(
-        --ak-flex-direction-md,
-        var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column))
-      )
+      var(--ak-flex-direction-md, var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row)))
     );
     align-items: var(
       --ak-align-items-lg,
-      var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, stretch)))
+      var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, normal)))
     );
     justify-content: var(
       --ak-justify-content-lg,
       var(
         --ak-justify-content-md,
-        var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start))
+        var(--ak-justify-content-sm, var(--ak-justify-content-base, normal))
       )
     );
-    gap: var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, 0))));
+    gap: var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, normal))));
     flex-grow: var(
       --ak-flex-grow-lg,
       var(--ak-flex-grow-md, var(--ak-flex-grow-sm, var(--ak-flex-grow-base, 0)))
@@ -376,7 +385,7 @@
     );
     min-width: var(
       --ak-min-width-lg,
-      var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, 0)))
+      var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, auto)))
     );
     max-width: var(
       --ak-max-width-lg,
@@ -444,7 +453,7 @@
     );
     border: var(
       --ak-border-lg,
-      var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
     );
     border-top: var(
       --ak-border-top-lg,
@@ -456,7 +465,10 @@
             --ak-border-top-base,
             var(
               --ak-border-lg,
-              var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+              var(
+                --ak-border-md,
+                var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+              )
             )
           )
         )
@@ -472,7 +484,10 @@
             --ak-border-bottom-base,
             var(
               --ak-border-lg,
-              var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+              var(
+                --ak-border-md,
+                var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+              )
             )
           )
         )
@@ -488,7 +503,10 @@
             --ak-border-right-base,
             var(
               --ak-border-lg,
-              var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+              var(
+                --ak-border-md,
+                var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+              )
             )
           )
         )
@@ -519,17 +537,14 @@
       --ak-flex-direction-xl,
       var(
         --ak-flex-direction-lg,
-        var(
-          --ak-flex-direction-md,
-          var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column))
-        )
+        var(--ak-flex-direction-md, var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row)))
       )
     );
     align-items: var(
       --ak-align-items-xl,
       var(
         --ak-align-items-lg,
-        var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, stretch)))
+        var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, normal)))
       )
     );
     justify-content: var(
@@ -538,13 +553,13 @@
         --ak-justify-content-lg,
         var(
           --ak-justify-content-md,
-          var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start))
+          var(--ak-justify-content-sm, var(--ak-justify-content-base, normal))
         )
       )
     );
     gap: var(
       --ak-gap-xl,
-      var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, 0))))
+      var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, normal))))
     );
     flex-grow: var(
       --ak-flex-grow-xl,
@@ -564,7 +579,7 @@
       --ak-min-width-xl,
       var(
         --ak-min-width-lg,
-        var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, 0)))
+        var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, auto)))
       )
     );
     width: var(
@@ -681,7 +696,7 @@
       --ak-border-xl,
       var(
         --ak-border-lg,
-        var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+        var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
       )
     );
     border-top: var(
@@ -700,7 +715,7 @@
                   --ak-border-lg,
                   var(
                     --ak-border-md,
-                    var(--ak-border-sm, var(--ak-border-base, 0 solid transparent))
+                    var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
                   )
                 )
               )
@@ -725,7 +740,7 @@
                   --ak-border-lg,
                   var(
                     --ak-border-md,
-                    var(--ak-border-sm, var(--ak-border-base, 0 solid transparent))
+                    var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
                   )
                 )
               )
@@ -750,7 +765,7 @@
                   --ak-border-lg,
                   var(
                     --ak-border-md,
-                    var(--ak-border-sm, var(--ak-border-base, 0 solid transparent))
+                    var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
                   )
                 )
               )

--- a/templates/theme/styles/display/virtual-table.css
+++ b/templates/theme/styles/display/virtual-table.css
@@ -9,6 +9,9 @@
   overscroll-behavior: contain;
   scrollbar-width: thin;
   scrollbar-color: var(--ak-color-border-strong) transparent;
+  transition:
+    border-color var(--ak-duration-fast) var(--ak-ease-standard),
+    box-shadow var(--ak-duration-fast) var(--ak-ease-standard);
 }
 
 :where([data-slot="virtual-table"][data-viewport="lg"]) {
@@ -30,11 +33,18 @@
 }
 
 :where([data-slot="virtual-table-head"]) {
-  background: var(--ak-color-surface);
+  background: var(--ak-color-surface-muted);
+  box-shadow: inset 0 -1px 0 var(--ak-color-border);
 }
 
 :where([data-slot="virtual-table-header-row"]) {
-  background: var(--ak-color-surface);
+  background: inherit;
+}
+
+:where([data-slot="virtual-table"][data-at-top="false"]) :where([data-slot="virtual-table-head"]) {
+  box-shadow:
+    inset 0 -1px 0 var(--ak-color-border),
+    var(--ak-shadow-md);
 }
 
 :where([data-slot="virtual-table-body"]) {
@@ -42,61 +52,174 @@
 }
 
 :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
-  padding: var(--ak-space-sm) var(--ak-space-xs);
-  border-block-end: 1px solid var(--ak-color-border);
-  color: var(--ak-color-text);
   font-size: var(--ak-font-size-sm);
   line-height: var(--ak-line-height-normal);
   text-align: start;
   vertical-align: middle;
+}
+
+:where([data-slot="virtual-table-header-cell"]) {
+  padding: 0 var(--ak-space-sm);
+  background: inherit;
+  color: var(--ak-color-text-muted);
+  font-weight: var(--ak-font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-:where([data-slot="virtual-table-header-cell"]) {
-  block-size: 2.5rem;
-  font-weight: var(--ak-font-weight-medium);
+:where([data-slot="virtual-table-cell"]) {
+  position: relative;
+  padding: 0;
+  border-block-end: 1px solid var(--ak-color-border);
+  color: var(--ak-color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 :where([data-slot="virtual-table-row"]) {
   background: transparent;
+  cursor: pointer;
   transition:
     background var(--ak-duration-fast) var(--ak-ease-standard),
-    color var(--ak-duration-fast) var(--ak-ease-standard);
+    color var(--ak-duration-fast) var(--ak-ease-standard),
+    box-shadow var(--ak-duration-fast) var(--ak-ease-standard);
+}
+
+:where([data-slot="virtual-table-row"])
+  :where(
+    [data-slot="input"]:not(:disabled, [data-disabled], [aria-disabled="true"]),
+    [data-slot="textarea"]:not(:disabled, [data-disabled], [aria-disabled="true"]),
+    [contenteditable="true"],
+    [role="searchbox"],
+    [role="spinbutton"],
+    [role="textbox"]
+  ) {
+  cursor: text;
 }
 
 :where([data-slot="virtual-table-row"]:hover) {
-  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
+  background: var(--ak-color-hover);
 }
 
 :where([data-slot="virtual-table-row"][data-selected="true"]) {
-  background: color-mix(in srgb, var(--ak-color-surface-muted) 50%, transparent);
+  background: var(--ak-color-selected);
   color: var(--ak-color-text);
+  box-shadow: inset 0 0 0 var(--ak-border-width-sm) var(--ak-color-selected-border);
+}
+
+:where(
+  [data-slot="virtual-table-row"][data-selected="true"]
+    > [data-slot="virtual-table-cell"]:first-child
+)::before {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  inline-size: var(--ak-border-width-md);
+  background: var(--ak-color-primary);
+  content: "";
 }
 
 :where([data-slot="virtual-table-spacer-row"]) {
   background: transparent;
 }
 
+:where([data-slot="virtual-table-cell-content"]) {
+  display: flex;
+  align-items: center;
+  gap: var(--ak-space-xs);
+  inline-size: 100%;
+  block-size: 100%;
+  min-inline-size: 0;
+  padding-inline: var(--ak-space-sm);
+  box-sizing: border-box;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:where(
+  [data-slot="virtual-table-cell-content"] > [data-slot="text"],
+  [data-slot="virtual-table-cell-content"] > [data-truncate="true"]
+) {
+  min-inline-size: 0;
+  max-inline-size: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 :where(
   [data-slot="virtual-table-header-cell"]:has([role="checkbox"]),
-  [data-slot="virtual-table-cell"]:has([role="checkbox"])
+  [data-slot="virtual-table-cell-content"]:has([role="checkbox"])
 ) {
   padding-inline-end: 0;
 }
 
-:where(
-  [data-slot="virtual-table-header-cell"] > [role="checkbox"],
-  [data-slot="virtual-table-cell"] > [role="checkbox"]
-) {
+:where([data-slot="virtual-table-header-cell"] > [role="checkbox"]) {
   transform: translateY(2px);
 }
 
-@media (max-width: 30rem) {
+:where(
+  [data-slot="virtual-table-body"]
+    > [data-slot="virtual-table-row"][data-terminal-row="true"]
+    > [data-slot="virtual-table-cell"]
+) {
+  border-block-end: 0;
+}
+
+:where([data-slot="virtual-table"]:focus-visible, [data-slot="virtual-table-table"]:focus-visible) {
+  outline: none;
+}
+
+:where(
+  [data-slot="virtual-table"]:focus-visible,
+  [data-slot="virtual-table"]:has([data-slot="virtual-table-table"]:focus-visible)
+) {
+  border-color: var(--ak-color-ring);
+  box-shadow: 0 0 0 var(--ak-focus-ring-width) var(--ak-color-focus-ring);
+}
+
+@media (forced-colors: active) {
+  :where([data-slot="virtual-table"]) {
+    border-color: CanvasText;
+  }
+
+  :where(
+    [data-slot="virtual-table"]:focus-visible,
+    [data-slot="virtual-table"]:has([data-slot="virtual-table-table"]:focus-visible)
+  ) {
+    outline: 2px solid Highlight;
+    outline-offset: 2px;
+    box-shadow: none;
+  }
+
+  :where([data-slot="virtual-table-head"]) {
+    background: Canvas;
+    color: CanvasText;
+    box-shadow: inset 0 -1px 0 CanvasText;
+  }
+
   :where([data-slot="virtual-table-header-cell"], [data-slot="virtual-table-cell"]) {
-    padding: var(--ak-space-sm) var(--ak-space-xs);
-    font-size: var(--ak-font-size-xs);
-    line-height: var(--ak-line-height-tight);
+    border-color: CanvasText;
+  }
+
+  :where([data-slot="virtual-table-row"][data-selected="true"]) {
+    background: Highlight;
+    color: HighlightText;
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+    box-shadow: none;
+  }
+
+  :where([data-slot="virtual-table-row"][data-selected="true"] > [data-slot="virtual-table-cell"]) {
+    color: HighlightText;
+  }
+
+  :where(
+    [data-slot="virtual-table-row"][data-selected="true"]
+      > [data-slot="virtual-table-cell"]:first-child
+  )::before {
+    background: HighlightText;
   }
 }

--- a/templates/theme/styles/layout/block.css
+++ b/templates/theme/styles/layout/block.css
@@ -1,5 +1,4 @@
 :where(
-  [data-slot="block"],
   [data-slot="container"],
   [data-slot="header"],
   [data-slot="main"],

--- a/templates/theme/styles/layout/layout.css
+++ b/templates/theme/styles/layout/layout.css
@@ -4,24 +4,24 @@
   --ak-display-md: var(--ak-display-sm);
   --ak-display-lg: var(--ak-display-md);
   --ak-display-xl: var(--ak-display-lg);
-  --ak-flex-direction-base: column;
+  --ak-flex-direction-base: row;
   --ak-flex-direction-sm: var(--ak-flex-direction-base);
   --ak-flex-direction-md: var(--ak-flex-direction-sm);
   --ak-flex-direction-lg: var(--ak-flex-direction-md);
   --ak-flex-direction-xl: var(--ak-flex-direction-lg);
   --ak-flex-wrap-base: nowrap;
   --ak-flex-wrap-sm: var(--ak-flex-wrap-base);
-  --ak-align-items-base: stretch;
+  --ak-align-items-base: normal;
   --ak-align-items-sm: var(--ak-align-items-base);
   --ak-align-items-md: var(--ak-align-items-sm);
   --ak-align-items-lg: var(--ak-align-items-md);
   --ak-align-items-xl: var(--ak-align-items-lg);
-  --ak-justify-content-base: flex-start;
+  --ak-justify-content-base: normal;
   --ak-justify-content-sm: var(--ak-justify-content-base);
   --ak-justify-content-md: var(--ak-justify-content-sm);
   --ak-justify-content-lg: var(--ak-justify-content-md);
   --ak-justify-content-xl: var(--ak-justify-content-lg);
-  --ak-gap-base: 0;
+  --ak-gap-base: normal;
   --ak-gap-sm: var(--ak-gap-base);
   --ak-gap-md: var(--ak-gap-sm);
   --ak-gap-lg: var(--ak-gap-md);
@@ -40,7 +40,7 @@
   --ak-flex-basis-sm: var(--ak-flex-basis-base);
   --ak-flex-basis-md: var(--ak-flex-basis-sm);
   --ak-flex-basis-lg: var(--ak-flex-basis-md);
-  --ak-min-width-base: 0;
+  --ak-min-width-base: auto;
   --ak-min-width-sm: var(--ak-min-width-base);
   --ak-min-width-md: var(--ak-min-width-sm);
   --ak-min-width-lg: var(--ak-min-width-md);
@@ -120,7 +120,7 @@
   --ak-overflow-x-sm: var(--ak-overflow-x-base);
   --ak-overflow-y-base: var(--ak-overflow-base);
   --ak-overflow-y-sm: var(--ak-overflow-y-base);
-  --ak-border-base: 0 solid transparent;
+  --ak-border-base: medium none currentcolor;
   --ak-border-sm: var(--ak-border-base);
   --ak-border-md: var(--ak-border-sm);
   --ak-border-lg: var(--ak-border-md);
@@ -156,15 +156,15 @@
 
   box-sizing: border-box;
   display: var(--ak-display-base, flex);
-  flex-direction: var(--ak-flex-direction-base, column);
+  flex-direction: var(--ak-flex-direction-base, row);
   flex-wrap: var(--ak-flex-wrap-base, nowrap);
-  align-items: var(--ak-align-items-base, stretch);
-  justify-content: var(--ak-justify-content-base, flex-start);
-  gap: var(--ak-gap-base, 0);
+  align-items: var(--ak-align-items-base, normal);
+  justify-content: var(--ak-justify-content-base, normal);
+  gap: var(--ak-gap-base, normal);
   flex-grow: var(--ak-flex-grow-base, 0);
   flex-shrink: var(--ak-flex-shrink-base, 1);
   flex-basis: var(--ak-flex-basis-base, auto);
-  min-width: var(--ak-min-width-base, 0);
+  min-width: var(--ak-min-width-base, auto);
   max-width: var(--ak-max-width-base, none);
   width: var(--ak-width-base, auto);
   min-height: var(--ak-min-height-base, auto);
@@ -186,10 +186,10 @@
   overflow: var(--ak-overflow-base, visible);
   overflow-x: var(--ak-overflow-x-base, var(--ak-overflow-base, visible));
   overflow-y: var(--ak-overflow-y-base, var(--ak-overflow-base, visible));
-  border: var(--ak-border-base, 0 solid transparent);
-  border-top: var(--ak-border-top-base, var(--ak-border-base, 0 solid transparent));
-  border-bottom: var(--ak-border-bottom-base, var(--ak-border-base, 0 solid transparent));
-  border-right: var(--ak-border-right-base, var(--ak-border-base, 0 solid transparent));
+  border: var(--ak-border-base, medium none currentcolor);
+  border-top: var(--ak-border-top-base, var(--ak-border-base, medium none currentcolor));
+  border-bottom: var(--ak-border-bottom-base, var(--ak-border-base, medium none currentcolor));
+  border-right: var(--ak-border-right-base, var(--ak-border-base, medium none currentcolor));
   border-radius: var(--ak-border-radius-base, 0);
   background: var(--ak-background-base, transparent);
   box-shadow: var(--ak-box-shadow-base, none);
@@ -198,15 +198,15 @@
 @media (min-width: 40rem) {
   :where([data-ak-layout="true"]) {
     display: var(--ak-display-sm, var(--ak-display-base, flex));
-    flex-direction: var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column));
+    flex-direction: var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row));
     flex-wrap: var(--ak-flex-wrap-sm, var(--ak-flex-wrap-base, nowrap));
-    align-items: var(--ak-align-items-sm, var(--ak-align-items-base, stretch));
-    justify-content: var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start));
-    gap: var(--ak-gap-sm, var(--ak-gap-base, 0));
+    align-items: var(--ak-align-items-sm, var(--ak-align-items-base, normal));
+    justify-content: var(--ak-justify-content-sm, var(--ak-justify-content-base, normal));
+    gap: var(--ak-gap-sm, var(--ak-gap-base, normal));
     flex-grow: var(--ak-flex-grow-sm, var(--ak-flex-grow-base, 0));
     flex-shrink: var(--ak-flex-shrink-sm, var(--ak-flex-shrink-base, 1));
     flex-basis: var(--ak-flex-basis-sm, var(--ak-flex-basis-base, auto));
-    min-width: var(--ak-min-width-sm, var(--ak-min-width-base, 0));
+    min-width: var(--ak-min-width-sm, var(--ak-min-width-base, auto));
     max-width: var(--ak-max-width-sm, var(--ak-max-width-base, none));
     width: var(--ak-width-sm, var(--ak-width-base, auto));
     min-height: var(--ak-min-height-sm, var(--ak-min-height-base, auto));
@@ -234,18 +234,27 @@
       --ak-overflow-y-sm,
       var(--ak-overflow-y-base, var(--ak-overflow-sm, var(--ak-overflow-base, visible)))
     );
-    border: var(--ak-border-sm, var(--ak-border-base, 0 solid transparent));
+    border: var(--ak-border-sm, var(--ak-border-base, medium none currentcolor));
     border-top: var(
       --ak-border-top-sm,
-      var(--ak-border-top-base, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(
+        --ak-border-top-base,
+        var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+      )
     );
     border-bottom: var(
       --ak-border-bottom-sm,
-      var(--ak-border-bottom-base, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(
+        --ak-border-bottom-base,
+        var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+      )
     );
     border-right: var(
       --ak-border-right-sm,
-      var(--ak-border-right-base, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(
+        --ak-border-right-base,
+        var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+      )
     );
     border-radius: var(--ak-border-radius-sm, var(--ak-border-radius-base, 0));
     background: var(--ak-background-sm, var(--ak-background-base, transparent));
@@ -258,20 +267,20 @@
     display: var(--ak-display-md, var(--ak-display-sm, var(--ak-display-base, flex)));
     flex-direction: var(
       --ak-flex-direction-md,
-      var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column))
+      var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row))
     );
     align-items: var(
       --ak-align-items-md,
-      var(--ak-align-items-sm, var(--ak-align-items-base, stretch))
+      var(--ak-align-items-sm, var(--ak-align-items-base, normal))
     );
     justify-content: var(
       --ak-justify-content-md,
-      var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start))
+      var(--ak-justify-content-sm, var(--ak-justify-content-base, normal))
     );
-    gap: var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, 0)));
+    gap: var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, normal)));
     flex-grow: var(--ak-flex-grow-md, var(--ak-flex-grow-sm, var(--ak-flex-grow-base, 0)));
     flex-shrink: var(--ak-flex-shrink-md, var(--ak-flex-shrink-sm, var(--ak-flex-shrink-base, 1)));
-    min-width: var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, 0)));
+    min-width: var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, auto)));
     max-width: var(--ak-max-width-md, var(--ak-max-width-sm, var(--ak-max-width-base, none)));
     width: var(--ak-width-md, var(--ak-width-sm, var(--ak-width-base, auto)));
     min-height: var(--ak-min-height-md, var(--ak-min-height-sm, var(--ak-min-height-base, auto)));
@@ -298,14 +307,17 @@
     position: var(--ak-position-md, var(--ak-position-sm, var(--ak-position-base, static)));
     top: var(--ak-top-md, var(--ak-top-sm, var(--ak-top-base, auto)));
     z-index: var(--ak-z-index-md, var(--ak-z-index-sm, var(--ak-z-index-base, auto)));
-    border: var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)));
+    border: var(
+      --ak-border-md,
+      var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+    );
     border-top: var(
       --ak-border-top-md,
       var(
         --ak-border-top-sm,
         var(
           --ak-border-top-base,
-          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
         )
       )
     );
@@ -315,7 +327,7 @@
         --ak-border-bottom-sm,
         var(
           --ak-border-bottom-base,
-          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
         )
       )
     );
@@ -325,7 +337,7 @@
         --ak-border-right-sm,
         var(
           --ak-border-right-base,
-          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+          var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
         )
       )
     );
@@ -349,23 +361,20 @@
     );
     flex-direction: var(
       --ak-flex-direction-lg,
-      var(
-        --ak-flex-direction-md,
-        var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column))
-      )
+      var(--ak-flex-direction-md, var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row)))
     );
     align-items: var(
       --ak-align-items-lg,
-      var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, stretch)))
+      var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, normal)))
     );
     justify-content: var(
       --ak-justify-content-lg,
       var(
         --ak-justify-content-md,
-        var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start))
+        var(--ak-justify-content-sm, var(--ak-justify-content-base, normal))
       )
     );
-    gap: var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, 0))));
+    gap: var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, normal))));
     flex-grow: var(
       --ak-flex-grow-lg,
       var(--ak-flex-grow-md, var(--ak-flex-grow-sm, var(--ak-flex-grow-base, 0)))
@@ -376,7 +385,7 @@
     );
     min-width: var(
       --ak-min-width-lg,
-      var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, 0)))
+      var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, auto)))
     );
     max-width: var(
       --ak-max-width-lg,
@@ -444,7 +453,7 @@
     );
     border: var(
       --ak-border-lg,
-      var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+      var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
     );
     border-top: var(
       --ak-border-top-lg,
@@ -456,7 +465,10 @@
             --ak-border-top-base,
             var(
               --ak-border-lg,
-              var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+              var(
+                --ak-border-md,
+                var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+              )
             )
           )
         )
@@ -472,7 +484,10 @@
             --ak-border-bottom-base,
             var(
               --ak-border-lg,
-              var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+              var(
+                --ak-border-md,
+                var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+              )
             )
           )
         )
@@ -488,7 +503,10 @@
             --ak-border-right-base,
             var(
               --ak-border-lg,
-              var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+              var(
+                --ak-border-md,
+                var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
+              )
             )
           )
         )
@@ -519,17 +537,14 @@
       --ak-flex-direction-xl,
       var(
         --ak-flex-direction-lg,
-        var(
-          --ak-flex-direction-md,
-          var(--ak-flex-direction-sm, var(--ak-flex-direction-base, column))
-        )
+        var(--ak-flex-direction-md, var(--ak-flex-direction-sm, var(--ak-flex-direction-base, row)))
       )
     );
     align-items: var(
       --ak-align-items-xl,
       var(
         --ak-align-items-lg,
-        var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, stretch)))
+        var(--ak-align-items-md, var(--ak-align-items-sm, var(--ak-align-items-base, normal)))
       )
     );
     justify-content: var(
@@ -538,13 +553,13 @@
         --ak-justify-content-lg,
         var(
           --ak-justify-content-md,
-          var(--ak-justify-content-sm, var(--ak-justify-content-base, flex-start))
+          var(--ak-justify-content-sm, var(--ak-justify-content-base, normal))
         )
       )
     );
     gap: var(
       --ak-gap-xl,
-      var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, 0))))
+      var(--ak-gap-lg, var(--ak-gap-md, var(--ak-gap-sm, var(--ak-gap-base, normal))))
     );
     flex-grow: var(
       --ak-flex-grow-xl,
@@ -564,7 +579,7 @@
       --ak-min-width-xl,
       var(
         --ak-min-width-lg,
-        var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, 0)))
+        var(--ak-min-width-md, var(--ak-min-width-sm, var(--ak-min-width-base, auto)))
       )
     );
     width: var(
@@ -681,7 +696,7 @@
       --ak-border-xl,
       var(
         --ak-border-lg,
-        var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, 0 solid transparent)))
+        var(--ak-border-md, var(--ak-border-sm, var(--ak-border-base, medium none currentcolor)))
       )
     );
     border-top: var(
@@ -700,7 +715,7 @@
                   --ak-border-lg,
                   var(
                     --ak-border-md,
-                    var(--ak-border-sm, var(--ak-border-base, 0 solid transparent))
+                    var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
                   )
                 )
               )
@@ -725,7 +740,7 @@
                   --ak-border-lg,
                   var(
                     --ak-border-md,
-                    var(--ak-border-sm, var(--ak-border-base, 0 solid transparent))
+                    var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
                   )
                 )
               )
@@ -750,7 +765,7 @@
                   --ak-border-lg,
                   var(
                     --ak-border-md,
-                    var(--ak-border-sm, var(--ak-border-base, 0 solid transparent))
+                    var(--ak-border-sm, var(--ak-border-base, medium none currentcolor))
                   )
                 )
               )

--- a/tests/browser/accessibility-visual-states.test.tsx
+++ b/tests/browser/accessibility-visual-states.test.tsx
@@ -159,6 +159,7 @@ describe("default-theme accessibility visual states", () => {
         // fallback keeps the cross-engine computed-style matrix deterministic.
         if (document.activeElement !== button) button.focus();
         expect(document.activeElement).toBe(button);
+        await settle();
         const styles = getComputedStyle(button);
         const parentStyles = getComputedStyle(button.parentElement!);
         const parent = parseColor(parentStyles.backgroundColor);
@@ -169,7 +170,7 @@ describe("default-theme accessibility visual states", () => {
           ratio(opaque(ring, parentRgb), parentRgb),
           `${mode}: ${surfaces[index]}`,
         ).toBeGreaterThanOrEqual(3);
-        expect(styles.boxShadow).not.toBe("none");
+        expect(styles.boxShadow, `${mode}: ${surfaces[index]}`).not.toBe("none");
         expect(button.getBoundingClientRect().width).toBe(before.width);
         expect(button.getBoundingClientRect().height).toBe(before.height);
       }

--- a/tests/browser/public-family-smoke.test.tsx
+++ b/tests/browser/public-family-smoke.test.tsx
@@ -232,4 +232,50 @@ describe("public family browser smoke", () => {
       Math.abs(prefix!.getBoundingClientRect().top - input!.getBoundingClientRect().top),
     ).toBeLessThan(1);
   });
+
+  it("should preserve native CSS initials for Block properties omitted by the caller", async () => {
+    testRoute("/families", () => (
+      <>
+        <style>{`
+          .partial-block,
+          .partial-control {
+            display: flex;
+            align-items: flex-start;
+          }
+        `}</style>
+        <Block className="partial-block">Content</Block>
+        <div className="partial-control">Control</div>
+      </>
+    ));
+
+    await createSPA({ root: container!, registry: createTestRegistry() });
+    await settle();
+
+    const block = container?.querySelector(".partial-block") as HTMLElement;
+    const control = container?.querySelector(".partial-control") as HTMLElement;
+    const blockStyle = getComputedStyle(block);
+    const controlStyle = getComputedStyle(control);
+
+    expect(blockStyle.display).toBe("flex");
+    expect(blockStyle.alignItems).toBe("flex-start");
+
+    for (const property of [
+      "flexDirection",
+      "flexWrap",
+      "justifyContent",
+      "gap",
+      "flexGrow",
+      "flexShrink",
+      "minWidth",
+      "maxWidth",
+      "boxSizing",
+      "position",
+      "borderTopStyle",
+      "borderTopWidth",
+      "borderRadius",
+      "boxShadow",
+    ] as const) {
+      expect(blockStyle[property], property).toBe(controlStyle[property]);
+    }
+  });
 });

--- a/tests/browser/visual-polish.test.tsx
+++ b/tests/browser/visual-polish.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from "@vitest/browser/context";
 import { afterEach, describe, expect, it } from "vite-plus/test";
 
 import "../../src/themes/default/index.css";
@@ -280,7 +281,7 @@ describe("visual polish contracts", () => {
     expect(getComputedStyle(menubarSubTrigger).textDecorationLine).toBe("none");
   });
 
-  it("should give virtualized list and table surfaces stable default polish", () => {
+  it("should give virtualized list and table surfaces stable default polish", async () => {
     document.body.innerHTML = `
       <div style="width: 320px; overflow: auto;">
         <div data-slot="virtual-list" data-viewport="lg">
@@ -292,7 +293,7 @@ describe("visual polish contracts", () => {
           </div>
         </div>
         <div data-slot="virtual-table" data-viewport="lg" data-table-width="compact">
-          <table data-slot="virtual-table-table">
+          <table data-slot="virtual-table-table" tabindex="0">
             <thead data-slot="virtual-table-head">
               <tr data-slot="virtual-table-header-row">
                 <th data-slot="virtual-table-header-cell">Time</th>
@@ -302,9 +303,30 @@ describe("visual polish contracts", () => {
             </thead>
             <tbody data-slot="virtual-table-body">
               <tr data-slot="virtual-table-row" data-selected="true">
-                <td data-slot="virtual-table-cell">09:17</td>
-                <td data-slot="virtual-table-cell">router</td>
-                <td data-slot="virtual-table-cell">Long route verification message</td>
+                <td data-slot="virtual-table-cell">
+                  <div data-slot="virtual-table-cell-content">09:17</div>
+                </td>
+                <td data-slot="virtual-table-cell">
+                  <div data-slot="virtual-table-cell-content">router</div>
+                </td>
+                <td data-slot="virtual-table-cell">
+                  <div data-slot="virtual-table-cell-content">
+                    Long route verification message
+                  </div>
+                </td>
+              </tr>
+              <tr data-slot="virtual-table-row" data-selected="false">
+                <td data-slot="virtual-table-cell">
+                  <div data-slot="virtual-table-cell-content">09:18</div>
+                </td>
+                <td data-slot="virtual-table-cell">
+                  <div data-slot="virtual-table-cell-content">worker</div>
+                </td>
+                <td data-slot="virtual-table-cell">
+                  <div data-slot="virtual-table-cell-content">
+                    Background reconciliation completed without errors
+                  </div>
+                </td>
               </tr>
               <tr data-slot="virtual-table-spacer-row">
                 <td style="height: 960px;"></td>
@@ -338,7 +360,13 @@ describe("visual polish contracts", () => {
     const selectedRow = wrapper.querySelector(
       '[data-slot="virtual-table-row"][data-selected="true"]',
     ) as HTMLElement;
+    const hoverRow = wrapper.querySelector(
+      '[data-slot="virtual-table-row"][data-selected="false"]',
+    ) as HTMLElement;
     const tableCell = wrapper.querySelector('[data-slot="virtual-table-cell"]') as HTMLElement;
+    const tableCellContent = wrapper.querySelector(
+      '[data-slot="virtual-table-cell-content"]',
+    ) as HTMLElement;
     const monoText = wrapper.querySelector('[data-slot="text"][data-font="mono"]') as HTMLElement;
     const wrappedText = wrapper.querySelector(
       '[data-slot="text"][data-wrap="anywhere"]',
@@ -359,8 +387,22 @@ describe("visual polish contracts", () => {
     expect(px(getComputedStyle(tableInner).minWidth)).toBe(640);
     expect(getComputedStyle(headerCell).fontWeight).not.toBe("400");
     expect(getComputedStyle(tableHead).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(tableHead).backgroundColor).not.toBe(
+      getComputedStyle(table).backgroundColor,
+    );
+    expect(getComputedStyle(tableHead).boxShadow).not.toBe("none");
+    expect(getComputedStyle(headerCell).color).not.toBe(getComputedStyle(tableCell).color);
     expect(getComputedStyle(selectedRow).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+    expect(getComputedStyle(selectedRow).boxShadow).not.toBe("none");
+    await userEvent.hover(hoverRow);
+    expect(getComputedStyle(hoverRow).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
     expect(getComputedStyle(tableCell).textOverflow).toBe("ellipsis");
+    expect(px(getComputedStyle(tableCellContent).paddingInlineStart)).toBeGreaterThanOrEqual(8);
+    expect(getComputedStyle(tableCellContent).alignItems).toBe("center");
+    expect(getComputedStyle(tableCellContent).textOverflow).toBe("ellipsis");
+    await userEvent.tab();
+    expect([table, tableInner]).toContain(document.activeElement);
+    expect(getComputedStyle(table).boxShadow).not.toBe("none");
     expect(getComputedStyle(monoText).fontVariantNumeric).toContain("tabular-nums");
     expect(getComputedStyle(monoText).textOverflow).toBe("ellipsis");
     expect(getComputedStyle(wrappedText).overflowWrap).toBe("anywhere");

--- a/tests/forced-colors/forced-colors.test.tsx
+++ b/tests/forced-colors/forced-colors.test.tsx
@@ -104,3 +104,40 @@ it("should preserve real controls and layered overlays in emulated forced colors
   const item = document.body.querySelector<HTMLElement>('[data-slot="dropdown-item"]')!;
   expect(getComputedStyle(item).outlineStyle).not.toBe("none");
 });
+
+it("should preserve virtual-table focus, hierarchy, and selection in emulated forced colors", async () => {
+  expect(matchMedia("(forced-colors: active)").matches).toBe(true);
+  container.innerHTML = `
+    <div data-slot="virtual-table">
+      <table data-slot="virtual-table-table" role="grid" tabindex="0">
+        <thead data-slot="virtual-table-head">
+          <tr data-slot="virtual-table-header-row">
+            <th data-slot="virtual-table-header-cell">Service</th>
+          </tr>
+        </thead>
+        <tbody data-slot="virtual-table-body">
+          <tr data-slot="virtual-table-row" data-selected="true">
+            <td data-slot="virtual-table-cell">
+              <div data-slot="virtual-table-cell-content"><span>router</span></div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  `;
+
+  const table = container.querySelector<HTMLElement>('[data-slot="virtual-table"]')!;
+  const focusTarget = container.querySelector<HTMLElement>('[data-slot="virtual-table-table"]')!;
+  const tableHead = container.querySelector<HTMLElement>('[data-slot="virtual-table-head"]')!;
+  const selectedRow = container.querySelector<HTMLElement>(
+    '[data-slot="virtual-table-row"][data-selected="true"]',
+  )!;
+
+  await userEvent.tab();
+  expect(document.activeElement).toBe(focusTarget);
+  expect(getComputedStyle(table).outlineStyle).not.toBe("none");
+  expect(getComputedStyle(table).borderTopStyle).not.toBe("none");
+  expect(getComputedStyle(tableHead).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+  expect(getComputedStyle(selectedRow).outlineStyle).not.toBe("none");
+  expect(getComputedStyle(selectedRow).backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+});

--- a/tests/unit/docs-surface.test.ts
+++ b/tests/unit/docs-surface.test.ts
@@ -10,6 +10,9 @@ const THEMES_DOC = join(DOCS_DIR, "askr-themes.md");
 const THEMING_DOC = join(DOCS_DIR, "theming.md");
 const ARCHITECTURE_DOC = join(DOCS_DIR, "architecture.md");
 const ACKNOWLEDGEMENTS = join(DOCS_DIR, "acknowledgements.md");
+const ROOT_THEMING = join(ROOT_DIR, "THEMING.md");
+const COMPONENT_ANATOMY = join(DOCS_DIR, "component-anatomy.md");
+const CHANGELOG = join(ROOT_DIR, "CHANGELOG.md");
 
 function sourceFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
@@ -20,6 +23,20 @@ function sourceFiles(directory: string): string[] {
 }
 
 describe("docs surface", () => {
+  it("should document native Block fallbacks and token-level dialog backdrop customization", () => {
+    const rootTheming = readFileSync(ROOT_THEMING, "utf-8");
+    const componentAnatomy = readFileSync(COMPONENT_ANATOMY, "utf-8");
+    const changelog = readFileSync(CHANGELOG, "utf-8");
+
+    expect(componentAnatomy).toContain("theme baseline for a plain element");
+    expect(componentAnatomy).toContain("display: flex");
+    expect(rootTheming).toContain("shipped `DialogOverlay` or `AlertDialogOverlay`");
+    expect(rootTheming).toContain("--ak-color-backdrop");
+    expect(rootTheming).toContain("--ak-z-modal-backdrop");
+    expect(rootTheming).toContain("Do not: bypass the shipped overlay treatment");
+    expect(changelog).toContain("Corrected `Block` layout fallbacks");
+  });
+
   it("should document the component catalog package surface", () => {
     const pkg = JSON.parse(readFileSync(PACKAGE_JSON, "utf-8")) as {
       exports?: Record<string, unknown>;

--- a/tests/unit/responsive-theme-contract.test.ts
+++ b/tests/unit/responsive-theme-contract.test.ts
@@ -87,6 +87,18 @@ describe("responsive theme contract", () => {
     for (const snippet of REQUIRED_LAYOUT_SNIPPETS) {
       expect(normalizedDefaultLayout).toContain(snippet);
     }
+
+    for (const nativeInitial of [
+      "--ak-flex-direction-base: row",
+      "--ak-align-items-base: normal",
+      "--ak-justify-content-base: normal",
+      "--ak-gap-base: normal",
+      "--ak-min-width-base: auto",
+      "--ak-border-base: medium none currentcolor",
+      "box-sizing: border-box",
+    ]) {
+      expect(normalizedDefaultLayout).toContain(nativeInitial);
+    }
   });
 
   it("should keep the generated theme template aligned with the default layout contract", () => {

--- a/tests/unit/visual-quality-contract.test.ts
+++ b/tests/unit/visual-quality-contract.test.ts
@@ -20,6 +20,11 @@ const CARD_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "card.css");
 const CATALOG_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "catalog.css");
 const TABLE_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "table.css");
 const VIRTUAL_TABLE_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "display", "virtual-table.css");
+const TEMPLATE_VIRTUAL_TABLE_CSS_FILE = join(
+  TEMPLATE_THEME_STYLES_DIR,
+  "display",
+  "virtual-table.css",
+);
 const BLOCK_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "layout", "block.css");
 const HEADER_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "shell", "header.css");
 const NAVBAR_CSS_FILE = join(DEFAULT_THEME_STYLES_DIR, "shell", "navbar.css");
@@ -45,6 +50,7 @@ describe("visual quality contract", () => {
   const catalogCss = read(CATALOG_CSS_FILE);
   const tableCss = read(TABLE_CSS_FILE);
   const virtualTableCss = read(VIRTUAL_TABLE_CSS_FILE);
+  const templateVirtualTableCss = read(TEMPLATE_VIRTUAL_TABLE_CSS_FILE);
   const blockCss = read(BLOCK_CSS_FILE);
   const headerCss = read(HEADER_CSS_FILE);
   const navbarCss = read(NAVBAR_CSS_FILE);
@@ -69,6 +75,7 @@ describe("visual quality contract", () => {
       "Responsive composition",
       "Mobile stress",
       "Supporting primitives",
+      "Virtual table",
       "Overlays",
       "Light mode",
       "Dark mode",
@@ -81,6 +88,10 @@ describe("visual quality contract", () => {
     expect(visualCheck).toContain("No clipped text");
     expect(visualCheck).toContain("Dense SaaS compositions");
     expect(visualCheck).toContain('data-theme="dark"');
+    expect(visualCheck).toContain('data-slot="virtual-table"');
+    expect(visualCheck).toContain('aria-label="Recent production deployments"');
+    expect(visualCheck).toContain('role="grid"');
+    expect(visualCheck).toContain('data-selected="${selected}"');
   });
 
   it("should ship a permanent forced-colors contract and keep the template synchronized", () => {
@@ -154,6 +165,34 @@ describe("visual quality contract", () => {
     expect(rootTheming).toContain("templates/theme/styles");
   });
 
+  it("should keep virtual-table geometry, interaction states, and template CSS aligned", () => {
+    expect(templateVirtualTableCss).toBe(virtualTableCss);
+    expect(virtualTableCss).not.toContain("block-size: 2.5rem;");
+
+    for (const contract of [
+      "background: var(--ak-color-surface-muted);",
+      "box-shadow: inset 0 -1px 0 var(--ak-color-border);",
+      '[data-at-top="false"]',
+      "var(--ak-shadow-md);",
+      "box-sizing: border-box;",
+      "block-size: 100%;",
+      "padding-inline: var(--ak-space-sm);",
+      "text-overflow: ellipsis;",
+      "cursor: pointer;",
+      '[data-slot="virtual-table-cell-content"]:has([role="checkbox"])',
+      '[data-slot="virtual-table-header-cell"] > [role="checkbox"]',
+      '[data-slot="virtual-table-row"][data-terminal-row="true"]',
+      '[data-slot="virtual-table-table"]:focus-visible',
+      ':has([data-slot="virtual-table-table"]:focus-visible)',
+      "background: var(--ak-color-hover);",
+      "background: var(--ak-color-selected);",
+      "background: var(--ak-color-primary);",
+      "@media (forced-colors: active)",
+    ]) {
+      expect(virtualTableCss).toContain(contract);
+    }
+  });
+
   it("should keep shared primitives visually aligned with the default theme baseline", () => {
     expect(buttonCss).toContain("--_button-height: var(--ak-density-control-height-md);");
     expect(buttonCss).toContain("background: var(--ak-color-primary);");
@@ -211,9 +250,7 @@ describe("visual quality contract", () => {
     expect(tableCss).toContain("white-space: normal;");
     expect(tableCss).toContain("background: color-mix(");
     expect(tableCss).toContain('[data-slot="table-row"]:last-child');
-    expect(virtualTableCss).toContain("block-size: 2.5rem;");
     expect(virtualTableCss).toContain("font-weight: var(--ak-font-weight-medium);");
-    expect(virtualTableCss).toContain("background: color-mix(");
     expect(virtualTableCss).toContain('[role="checkbox"]');
     expect(virtualTableCss).toContain("background: var(--ak-color-surface);");
   });

--- a/visual-check.html
+++ b/visual-check.html
@@ -449,6 +449,113 @@
         border-radius: var(--ak-radius-lg);
       }
 
+      .virtual-table-audit-frame {
+        display: grid;
+        gap: 0.75rem;
+        min-inline-size: 0;
+      }
+
+      .virtual-table-audit-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+      }
+
+      .virtual-table-audit-summary {
+        display: grid;
+        gap: 0.2rem;
+        min-inline-size: 0;
+      }
+
+      .virtual-table-audit-summary span {
+        color: var(--ak-color-text-muted);
+        font-size: var(--ak-font-size-sm);
+      }
+
+      .virtual-table-audit {
+        block-size: 20rem;
+      }
+
+      .virtual-table-audit.compact-table-wrap {
+        overflow: auto;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-table"]) {
+        min-inline-size: 62rem;
+        table-layout: fixed;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-head"]) {
+        position: sticky;
+        inset-block-start: 0;
+        z-index: 2;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-header-row"]) {
+        block-size: 3rem;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-header-cell"]) {
+        block-size: 3rem;
+        max-block-size: 3rem;
+        box-sizing: border-box;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-row"]) {
+        block-size: 3rem;
+        overflow: hidden;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-cell"]) {
+        position: relative;
+        block-size: 3rem;
+        max-block-size: 3rem;
+        box-sizing: border-box;
+        overflow: hidden;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-cell-content"]) {
+        position: absolute;
+        inset: 0;
+        overflow: hidden;
+      }
+
+      .virtual-table-audit :where([data-slot="virtual-table-spacer-row"] > td) {
+        block-size: 12rem;
+        padding: 0;
+        border: 0;
+      }
+
+      .virtual-table-audit :where([data-audit-column="select"]) {
+        inline-size: 3rem;
+      }
+
+      .virtual-table-audit :where([data-audit-column="time"]) {
+        inline-size: 9rem;
+      }
+
+      .virtual-table-audit :where([data-audit-column="deployment"]) {
+        inline-size: 18rem;
+      }
+
+      .virtual-table-audit :where([data-audit-column="environment"]) {
+        inline-size: 8rem;
+      }
+
+      .virtual-table-audit :where([data-audit-column="status"]) {
+        inline-size: 8rem;
+      }
+
+      .virtual-table-audit :where([data-audit-column="owner"]) {
+        inline-size: 9rem;
+      }
+
+      .virtual-table-audit :where([data-audit-column="actions"]) {
+        inline-size: 5rem;
+      }
+
       .preview-surface :where([data-slot="navbar"]) {
         display: flex;
         align-items: center;
@@ -909,6 +1016,238 @@
           </table>
         </div>`;
 
+      const virtualTableAuditRows = [
+        {
+          time: "Aug 22, 14:32:18",
+          deployment: "customer-hub-api / deploy #1842",
+          environment: "Production",
+          status: "Healthy",
+          statusVariant: "success",
+          owner: "Avery Chen",
+        },
+        {
+          time: "Aug 22, 14:28:04",
+          deployment: "billing-reconciler / canary promotion #992",
+          environment: "Production",
+          status: "Deploying",
+          statusVariant: "info",
+          owner: "Morgan Lee",
+        },
+        {
+          time: "Aug 22, 14:17:51",
+          deployment: "identity-api / rollback guard verification #6401",
+          environment: "Staging",
+          status: "Review",
+          statusVariant: "warning",
+          owner: "Riley Patel",
+        },
+        {
+          time: "Aug 22, 14:09:36",
+          deployment: "pdf-renderer / immutable-live-alias-rollout-20260822.3",
+          environment: "Production",
+          status: "Healthy",
+          statusVariant: "success",
+          owner: "Sam Rivera",
+          selected: true,
+        },
+        {
+          time: "Aug 22, 13:58:12",
+          deployment: "search-indexer / regional backfill #318",
+          environment: "Preview",
+          status: "Queued",
+          statusVariant: "secondary",
+          owner: "Taylor Kim",
+        },
+        {
+          time: "Aug 22, 13:42:29",
+          deployment: "websocket-gateway / connection-drain #2274",
+          environment: "Production",
+          status: "Failed",
+          statusVariant: "danger",
+          owner: "Jordan Bell",
+        },
+        {
+          time: "Aug 22, 13:31:07",
+          deployment: "messaging-topology / broker rebalance #810",
+          environment: "Staging",
+          status: "Healthy",
+          statusVariant: "success",
+          owner: "Casey Wong",
+        },
+        {
+          time: "Aug 22, 13:22:44",
+          deployment: "audit-log-archiver / retention sweep #1289",
+          environment: "Production",
+          status: "Healthy",
+          statusVariant: "success",
+          owner: "Alex Smith",
+        },
+        {
+          time: "Aug 22, 13:14:03",
+          deployment: "customer-data-export / eu-west checkpoint #556",
+          environment: "Development",
+          status: "Paused",
+          statusVariant: "secondary",
+          owner: "Jamie Park",
+        },
+        {
+          time: "Aug 22, 13:05:27",
+          deployment: "notification-worker / queue recovery #1097",
+          environment: "Production",
+          status: "Review",
+          statusVariant: "warning",
+          owner: "Drew Martin",
+        },
+      ];
+
+      const virtualTableAuditHeaders = [
+        ["select", "Select"],
+        ["time", "Started"],
+        ["deployment", "Deployment"],
+        ["environment", "Environment"],
+        ["status", "Status"],
+        ["owner", "Owner"],
+        ["actions", "Actions"],
+      ];
+
+      const virtualTableAuditRowsMarkup = virtualTableAuditRows
+        .map((row, index) => {
+          const selected = row.selected === true;
+          const rowNumber = index + 2;
+          const rowKey = `deployment-${index + 1}`;
+          const checkbox = `
+            <button
+              type="button"
+              data-slot="checkbox"
+              role="checkbox"
+              aria-checked="${selected}"
+              aria-label="Select ${row.deployment}"
+              ${selected ? 'data-state="checked"' : ""}
+            ></button>`;
+          const status = `
+            <span
+              class="badge badge-${row.statusVariant}"
+              data-slot="badge"
+              data-variant="${row.statusVariant}"
+            >${row.status}</span>`;
+          const action = `
+            <button
+              type="button"
+              class="btn btn-ghost btn-sm"
+              data-slot="button"
+              data-variant="ghost"
+              data-size="sm"
+              aria-label="Open actions for ${row.deployment}"
+            >More</button>`;
+
+          const cells = [
+            checkbox,
+            `<span data-slot="text" data-numeric="tabular" data-truncate="true">${row.time}</span>`,
+            `<span data-slot="text" data-truncate="true" title="${row.deployment}">${row.deployment}</span>`,
+            row.environment,
+            status,
+            `<span data-slot="text" data-truncate="true">${row.owner}</span>`,
+            action,
+          ]
+            .map(
+              (content, columnIndex) => `
+                <td
+                  data-slot="virtual-table-cell"
+                  data-column-id="${virtualTableAuditHeaders[columnIndex][0]}"
+                  aria-colindex="${columnIndex + 1}"
+                >
+                  <div data-slot="virtual-table-cell-content">${content}</div>
+                </td>`,
+            )
+            .join("");
+
+          return `
+            <tr
+              data-slot="virtual-table-row"
+              data-row-index="${index}"
+              data-row-key="${rowKey}"
+              data-selected="${selected}"
+              aria-rowindex="${rowNumber}"
+              aria-selected="${selected}"
+            >${cells}</tr>`;
+        })
+        .join("");
+
+      const virtualTableContent = `
+        <div class="virtual-table-audit-frame">
+          <div class="virtual-table-audit-toolbar">
+            <div class="virtual-table-audit-summary">
+              <strong>Recent production deployments</strong>
+              <span>48 records across four environments</span>
+            </div>
+            <div class="row">
+              <span class="badge badge-success" data-slot="badge" data-variant="success">
+                Live
+              </span>
+              <button class="btn btn-outline btn-sm" data-slot="button" data-size="sm">
+                Filter deployments
+              </button>
+            </div>
+          </div>
+          <div
+            class="virtual-table-audit compact-table-wrap"
+            data-slot="virtual-table"
+            data-virtual-table="true"
+            data-viewport="lg"
+            data-table-width="compact"
+            data-at-top="true"
+            data-at-bottom="false"
+            data-empty="false"
+          >
+            <table
+              data-slot="virtual-table-table"
+              data-virtual-table-table="true"
+              role="grid"
+              aria-label="Recent production deployments"
+              aria-rowcount="49"
+              aria-colcount="7"
+              tabindex="0"
+            >
+              <colgroup>
+                ${virtualTableAuditHeaders
+                  .map(([column]) => `<col data-audit-column="${column}" />`)
+                  .join("")}
+              </colgroup>
+              <thead data-slot="virtual-table-head">
+                <tr data-slot="virtual-table-header-row" aria-rowindex="1">
+                  ${virtualTableAuditHeaders
+                    .map(
+                      ([column, label], columnIndex) => `
+                        <th
+                          data-slot="virtual-table-header-cell"
+                          data-column-id="${column}"
+                          scope="col"
+                          aria-colindex="${columnIndex + 1}"
+                        >
+                          ${
+                            column === "select"
+                              ? '<button type="button" data-slot="checkbox" role="checkbox" aria-checked="mixed" aria-label="Select all visible deployments"></button>'
+                              : label
+                          }
+                        </th>`,
+                    )
+                    .join("")}
+                </tr>
+              </thead>
+              <tbody data-slot="virtual-table-body">
+                ${virtualTableAuditRowsMarkup}
+                <tr
+                  data-slot="virtual-table-spacer-row"
+                  role="presentation"
+                  aria-hidden="true"
+                >
+                  <td colspan="7"></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>`;
+
       const displayContent = `
         <div class="stack">
           <div class="stack" aria-label="Card list recipe">
@@ -1252,6 +1591,12 @@
               content: tableContent,
             },
             {
+              title: "Virtual table",
+              note: "Scrollable deployment data with sticky headers, selection, status, and row actions.",
+              span: "full",
+              content: virtualTableContent,
+            },
+            {
               title: "Display states",
               note: "List rows, progress, and skeleton in one dense surface.",
               content: displayContent,
@@ -1385,6 +1730,17 @@
         </section>`;
 
       document.getElementById("audit-root").innerHTML = hero + sections.map(renderSection).join("");
+
+      document.querySelectorAll('[data-slot="virtual-table"]').forEach((table) => {
+        const syncScrollEdges = () => {
+          const maximumScrollTop = Math.max(0, table.scrollHeight - table.clientHeight);
+          table.dataset.atTop = String(table.scrollTop <= 0);
+          table.dataset.atBottom = String(table.scrollTop >= maximumScrollTop - 1);
+        };
+
+        table.addEventListener("scroll", syncScrollEdges, { passive: true });
+        syncScrollEdges();
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- preserve virtual-row dividers unless UI marks the actual terminal dataset row
- restore native Block flex initial values while retaining the global border-box contract
- document and exercise the shipped Dialog and AlertDialog overlays
- keep source and generated theme templates synchronized
- add browser, forced-colors, responsive, and visual-contract regressions

Closes #94
Closes #95

## Validation

- `npm run check`
- 602 unit tests passed
- 204 browser tests passed
- typecheck, formatting, build, and contract lanes passed
