### PR TITLE
docs: clarify theme behavior boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ export function AppShell() {
       </ButtonGroup>
 
       <Field>
-        <Label for="workspace">Workspace</Label>
+        <Label htmlFor="workspace">Workspace</Label>
         <InputGroup>
           <Input id="workspace" name="workspace" />
         </InputGroup>
@@ -121,11 +121,27 @@ diverge instead of emitting unstyled markup. Use the same wrapper for an SSR
 - `@askrjs/charts` for charts; chart components are intentionally not exported
   from `@askrjs/themes`.
 
+The default theme is intentionally neutral and uses a grayscale primary scale.
+Choose a preset or override the primary tokens before shipping when the product
+needs a branded accent:
+
+```css
+:root {
+  --ak-color-primary: oklch(0.55 0.18 255);
+  --ak-color-primary-soft: oklch(0.95 0.04 255);
+  --ak-color-primary-ink: oklch(0.3 0.12 255);
+}
+```
+
+See [THEMING.md](./THEMING.md#required-tokens) for the complete primary,
+hover, active, focus, and contrast contract.
+
 ### Styling-only compatibility wrappers
 
-`DataTable`, `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle`
-are styling-only catalog compatibility wrappers. Their names do not promise a
-data-grid or panel-resizing runtime:
+`DataTable`, `DatePicker`, `TabsList`, `TabsTrigger`, `TabsContent`,
+`ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle` are styling-only
+catalog compatibility wrappers. Their names do not promise a data-grid,
+headless tabs, calendar, or panel-resizing runtime:
 
 - `DataTable` provides a `data-table` container slot. It does not sort, filter,
   select, or paginate. Compose semantic `Table` or `VirtualTable` primitives
@@ -134,12 +150,19 @@ data-grid or panel-resizing runtime:
   and separator slots only. The group does not implement pointer or keyboard
   resizing, track dimensions, or provide the ARIA value state required by an
   interactive splitter.
+- `DatePicker` is a layout slot around `DatePickerInput`. The input is the
+  browser-native `<input type="date">`; the wrapper does not provide a custom
+  popup calendar, localized formatter, or calendar-grid keyboard model.
+- `TabsList`, `TabsTrigger`, and `TabsContent` provide styling slots only. They
+  do not coordinate selection, panels, ARIA state, or arrow-key navigation.
+  `Tabs` and `Tab` are separate, functional navigation-link components; they
+  are not a headless tab-panel system and do not share state with these slots.
 
 These names remain exported for catalog compatibility. If an application needs
-real resize behavior today, supply the pointer, keyboard, sizing, and ARIA
-contract in application code or a dedicated behavior dependency. A future Askr
-resize primitive must be implemented and tested in `@askrjs/ui` before themes
-can compose and style it.
+real tab-panel, calendar, or resize behavior today, supply that state, keyboard,
+and ARIA contract in application code or a dedicated behavior dependency. A
+future Askr behavior primitive must be implemented and tested in `@askrjs/ui`
+before themes can compose and style it.
 
 ## Theme Contract
 

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -566,12 +566,15 @@ export function DataTable(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "data-table" });
 }
 
-/** Renders the `date-picker` part of the shadcn-compatible catalog primitives. */
+/**
+ * Styling-only `date-picker` container. It does not implement a popup calendar, formatting, or
+ * calendar-grid keyboard behavior; pair it with {@link DatePickerInput} for a native date input.
+ */
 export function DatePicker(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "date-picker" });
 }
 
-/** Renders the date picker's `<input type="date">` by default. */
+/** Native `<input type="date">` styling slot; browser behavior and localization remain native. */
 export function DatePickerInput(props: CatalogComponentProps): JSX.Element {
   const { ref, class: className, type = "date", ...rest } = props;
   const finalProps = mergeProps(rest, {
@@ -880,17 +883,17 @@ export function ResizableHandle(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "resizable-handle" });
 }
 
-/** Renders the `tabs-list` part of the shadcn-compatible catalog primitives. */
+/** Styling-only tabs-list slot; it does not own tab selection, ARIA state, or keyboard behavior. */
 export function TabsList(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "tabs-list" });
 }
 
-/** Renders the `tabs-content` part of the shadcn-compatible catalog primitives. */
+/** Styling-only trigger button; it does not select or associate a tab panel. */
 export function TabsTrigger(props: CatalogComponentProps): JSX.Element {
   return buttonPart(props, "tabs-trigger", "tab");
 }
 
-/** Renders the `tabs-content` part of the shadcn-compatible catalog primitives. */
+/** Styling-only tabs-content slot; visibility and panel association are consumer-owned. */
 export function TabsContent(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "tabs-content" });
 }


### PR DESCRIPTION
Closes #103
Closes #104
Closes #105

## Summary
- identify DatePicker and tab-part exports as styling-only compatibility slots
- distinguish navigation Tabs from a stateful tab-panel primitive
- correct the Label example to use `htmlFor`
- record the neutral-default decision and show the supported primary-token override

## Validation
- `npm run check` (617 unit, 59 jsdom, 216 browser, and 2 forced-colors tests passed)

No package versions were changed and nothing was published.