### PR TITLE
docs: classify styling-only widget anatomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,21 @@ hover, active, focus, and contrast contract.
 
 ### Styling-only compatibility wrappers
 
-`DataTable`, `DatePicker`, `TabsList`, `TabsTrigger`, `TabsContent`,
-`ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle` are styling-only
-catalog compatibility wrappers. Their names do not promise a data-grid,
-headless tabs, calendar, or panel-resizing runtime:
+The following catalog families are styling-only compatibility anatomy. Their
+names do not promise widget state, keyboard interaction, focus management, or
+complete ARIA relationships:
+
+- `TabsList`, `TabsTrigger`, and `TabsContent`
+- `Combobox`, `ComboboxInput`, `ComboboxList`, and `ComboboxOption`
+- `Calendar*`, `DatePicker`, and `DatePickerInput`
+- `Command*` (except the separately documented functional `CommandPalette`)
+- `NavigationMenu*`
+- `Carousel*`
+- `ResizablePanelGroup`, `ResizablePanel`, and `ResizableHandle`
+- `InputOTP`, `InputOTPGroup`, `InputOTPSlot`, and `InputOTPSeparator`
+- `DataTable`
+
+Specifically:
 
 - `DataTable` provides a `data-table` container slot. It does not sort, filter,
   select, or paginate. Compose semantic `Table` or `VirtualTable` primitives
@@ -157,12 +168,25 @@ headless tabs, calendar, or panel-resizing runtime:
   do not coordinate selection, panels, ARIA state, or arrow-key navigation.
   `Tabs` and `Tab` are separate, functional navigation-link components; they
   are not a headless tab-panel system and do not share state with these slots.
+- `Combobox*` does not manage a value, filter options, open a popup, move focus,
+  or emit the combobox/listbox ARIA relationship.
+- `Calendar*` exposes visual day/month slots but does not own dates, selection,
+  grid focus, localization, or month navigation. Its previous/next/day buttons
+  remain ordinary caller-controlled buttons.
+- `Command*` exposes search/list/item styling but does not filter, select, or
+  move focus. `CommandPalette` is a separate functional dialog composition.
+- `NavigationMenu*` exposes navigation layout but does not coordinate content,
+  disclosure state, roving focus, or arrow-key behavior.
+- `Carousel*` exposes slide and control slots but does not track an active
+  slide, scroll, announce changes, or implement keyboard controls.
+- `InputOTP*` exposes groups, cells, and separators but deliberately renders no
+  hidden input and owns no value, focus, paste, or validation behavior.
 
 These names remain exported for catalog compatibility. If an application needs
-real tab-panel, calendar, or resize behavior today, supply that state, keyboard,
-and ARIA contract in application code or a dedicated behavior dependency. A
-future Askr behavior primitive must be implemented and tested in `@askrjs/ui`
-before themes can compose and style it.
+behavior for any of these families today, use a dedicated behavior dependency
+and compose these slots only as presentation. A future Askr behavior primitive
+must be implemented and tested in `@askrjs/ui` before themes can compose and
+style it; themes must never duplicate behavioral state.
 
 ## Theme Contract
 

--- a/src/components/catalog.tsx
+++ b/src/components/catalog.tsx
@@ -336,7 +336,7 @@ export function BreadcrumbEllipsis(props: CatalogComponentProps): JSX.Element {
   );
 }
 
-/** Renders the `calendar` part of the shadcn-compatible catalog primitives. */
+/** Styling-only calendar anatomy; it does not own dates, grid focus, selection, or month navigation. */
 export function Calendar(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "calendar" });
 }
@@ -431,7 +431,7 @@ export function CalendarDay(
   );
 }
 
-/** Renders the `carousel` part of the shadcn-compatible catalog primitives. */
+/** Styling-only carousel anatomy; it does not own an active slide, scrolling, or keyboard navigation. */
 export function Carousel(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "carousel" });
 }
@@ -458,7 +458,7 @@ export function CarouselNext(props: CatalogComponentProps): JSX.Element {
   return buttonPart({ children, ...rest }, "carousel-next", "btn btn-icon");
 }
 
-/** Renders the `combobox` part of the shadcn-compatible catalog primitives. */
+/** Styling-only combobox anatomy; it does not own value, popup, filtering, focus, or ARIA state. */
 export function Combobox(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "combobox" });
 }
@@ -485,7 +485,7 @@ export function ComboboxOption(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "combobox-option" });
 }
 
-/** Renders the `command` part of the shadcn-compatible catalog primitives. */
+/** Styling-only command anatomy; it does not own filtering, selection, focus, or keyboard commands. */
 export function Command(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "command" });
 }
@@ -662,7 +662,7 @@ export function FieldSeparator(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "field-separator", role: "separator" });
 }
 
-/** Renders the `input-otp` part of the shadcn-compatible catalog primitives. */
+/** Styling-only OTP anatomy; it does not render an input or own value, focus, paste, or validation behavior. */
 export function InputOTP(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "input-otp", role: "group" });
 }
@@ -766,7 +766,7 @@ export function NativeSelect(props: CatalogComponentProps): JSX.Element {
   return <select {...finalProps}>{children}</select>;
 }
 
-/** Renders the `navigation-menu` part of the shadcn-compatible catalog primitives. */
+/** Styling-only navigation-menu anatomy; it does not own disclosure, roving focus, or keyboard behavior. */
 export function NavigationMenu(props: CatalogComponentProps): JSX.Element {
   return catalogPart(props, { slot: "navigation-menu", element: "nav" });
 }

--- a/tests/unit/package-surface.test.ts
+++ b/tests/unit/package-surface.test.ts
@@ -44,10 +44,20 @@ const A11Y_EXPORT_PATTERN = new RegExp(
   `${["A11Y", "CONTRACT"].join("_")}|${["A11y", "Contract"].join("")}`,
 );
 const REPORTED_CATALOG_WRAPPERS = [
+  "Calendar",
+  "Carousel",
+  "Combobox",
+  "Command",
   "DataTable",
+  "DatePicker",
+  "InputOTP",
+  "NavigationMenu",
   "ResizablePanelGroup",
   "ResizablePanel",
   "ResizableHandle",
+  "TabsList",
+  "TabsTrigger",
+  "TabsContent",
 ] as const;
 const COMPONENT_DIST_ARTIFACTS = ["dist/components.js", "dist/components.d.ts"] as const;
 const WILDCARD_MODULE_BINDING = "*" as const;
@@ -294,6 +304,23 @@ describe("package surface", () => {
       const docs = declarationDocumentation(declarations, component);
       expect(docs, component).toContain("Styling-only");
       expect(docs, component).toContain("does not implement resizing");
+    }
+
+    for (const component of [
+      "Calendar",
+      "Carousel",
+      "Combobox",
+      "Command",
+      "DatePicker",
+      "InputOTP",
+      "NavigationMenu",
+      "TabsList",
+      "TabsTrigger",
+      "TabsContent",
+    ]) {
+      expect(declarationDocumentation(declarations, component), component).toContain(
+        "Styling-only",
+      );
     }
   }, 30_000);
 


### PR DESCRIPTION
## Summary

- explicitly classify all nine widget-like catalog families as styling-only anatomy
- document the exact state, keyboard, focus, and ARIA behavior each family does not own
- publish the contract in generated declarations and prove wrappers do not source behavior from `@askrjs/ui`
- reserve behavioral ownership for tested UI primitives rather than duplicated themes state

Closes askrjs/askr-ui#88.

## Validation

- `npm run check`
- package version remains `0.2.3`; no package or publish metadata changed