### PR TITLE
fix: harden theme composition and layout contracts

### DIFF
--- a/docs/askr-themes.md
+++ b/docs/askr-themes.md
@@ -126,7 +126,13 @@ const open = state(false);
       <CommandInput aria-label="Search documentation" />
     </CommandHeader>
     <CommandPaletteList>
-      <CommandPaletteLink href="/getting-started" onBeforeNavigate={() => cancelPendingSearch()}>
+      <CommandPaletteLink
+        href="/getting-started"
+        onBeforeNavigate={(event) => {
+          cancelPendingSearch();
+          if (!canNavigate()) event.preventDefault();
+        }}
+      >
         Getting started
       </CommandPaletteLink>
     </CommandPaletteList>
@@ -138,7 +144,8 @@ The command input receives focus by default on mouse, keyboard, and programmatic
 opens. Set `initialFocus` to another selector or target callback when needed.
 Tab and Shift+Tab remain contained while the palette is open, and result links
 stay semantic anchors while closing and cleaning up the palette before
-same-origin Askr navigation. Set
+same-origin Askr navigation. `onBeforeNavigate` receives the press event; call
+`preventDefault()` to keep both navigation and palette dismissal from running. Set
 `closeOnEscape={false}` or `closeOnBackdrop={false}` only when the product has
 another clear dismissal path. The composition performs no browser work during
 SSR or SSG.
@@ -163,6 +170,9 @@ Use explicit prop names. The API intentionally avoids shorthand aliases such as
   <p>Page content.</p>
 </Block>
 ```
+
+`rowFrom="lg"` means column below `lg` and row from `lg` upward. An explicit
+responsive `direction` still overrides either side of that shorthand.
 
 Responsive behavior uses one pattern everywhere:
 
@@ -189,7 +199,9 @@ another layout system.
 - `Header`: semantic header with surface background and optional sticky mode.
 - `Main`: semantic main region that can grow inside app frames.
 - `Section`: semantic page section with default vertical rhythm.
-- `Aside` and `Sidebar`: semantic side regions.
+- `Aside` and `Sidebar`: semantic side regions. `collapsible="icon"` uses the
+  sidebar rail width, and `side="right"` docks the sidebar after its inset in
+  the standard `SidebarScope` composition.
 - `Navbar`, `NavBrand`, `NavDropdown`, `NavGroup`, `NavLink`, and `NavItem`: lightweight navigation structure.
 
 ```tsx
@@ -256,7 +268,8 @@ export function ProjectsPage() {
 
 Use `CopyButton` as the canonical copy-to-clipboard control for identifiers,
 tokens, and URLs. It copies asynchronously, shows a success icon for two
-seconds, and announces both success and failure to assistive technology.
+seconds after the latest copy, and announces both success and failure to
+assistive technology.
 
 ```tsx
 <CopyButton text={project.id} label="Copy project ID" />

--- a/docs/regression-coverage.md
+++ b/docs/regression-coverage.md
@@ -29,6 +29,7 @@ exports, class/slot structure, CSS tokens, responsive layout, and composed
 | Slot/prop passthrough drift       | Unit or jsdom tests must assert `asChild`, class merging, data slots, ARIA passthrough, and ref-safe composition where applicable.                           |
 | Route/theme persistence           | jsdom and browser tests must assert theme state across navigation and reload-shaped flows.                                                                   |
 | Theme identity coordination       | Nested and sibling scopes with distinct storage keys must cover stored adoption, storage events, initial arbitration, and explicit ownership.                |
+| Browser global-state isolation    | Test files that mutate shared browser state such as the viewport must run serially within each browser instance.                                             |
 | Cross-package version drift       | Package surface tests and integration smoke must fail before a released `askr-ui` or `askr` dependency breaks themed exports.                                |
 
 ## Current focused follow-ups

--- a/docs/regression-coverage.md
+++ b/docs/regression-coverage.md
@@ -22,9 +22,13 @@ exports, class/slot structure, CSS tokens, responsive layout, and composed
 | Responsive navigation regressions | Browser tests must cover long labels, breakpoint collapse, menu close paths, Escape, resize, and nav activation.                                             |
 | Overlay composition drift         | Browser tests must compose themed overlays through public exports and assert real `askr-ui` behavior remains intact.                                         |
 | Command palette regressions       | Browser tests must cover mouse, keyboard, and programmatic focus; Tab containment; dismissal opt-outs; semantic result links; and cleanup before navigation. |
+| Cancelable callback contracts     | Browser tests must call `preventDefault()` from each documented cancelable callback and assert every guarded action is suppressed.                           |
+| Rendered layout contracts         | Browser tests must assert computed direction, width, and physical placement for responsive and sidebar layout props, not only variable strings.              |
+| Persistent component timers       | Repeated interactions across rerenders must refresh one lifetime-owned timer and release its cleanup listener at unmount.                                    |
 | Token or selector drift           | Unit contracts must assert semantic token names, selectors, aliases, contrast, and template parity.                                                          |
 | Slot/prop passthrough drift       | Unit or jsdom tests must assert `asChild`, class merging, data slots, ARIA passthrough, and ref-safe composition where applicable.                           |
 | Route/theme persistence           | jsdom and browser tests must assert theme state across navigation and reload-shaped flows.                                                                   |
+| Theme identity coordination       | Nested and sibling scopes with distinct storage keys must cover stored adoption, storage events, initial arbitration, and explicit ownership.                |
 | Cross-package version drift       | Package surface tests and integration smoke must fail before a released `askr-ui` or `askr` dependency breaks themed exports.                                |
 
 ## Current focused follow-ups

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -92,6 +92,12 @@ export function AppTheme({ children }: { children?: unknown }) {
 Use `CAT_THEME_NAMES` for compact toggles that cycle only through the preset
 family.
 
+Each `ThemeScope` reads and listens to its own `storageKey`, including nested
+scopes. Independent top-level scopes with different keys keep their local
+state isolated; mounting a later sibling does not replace the initial document
+theme merely because it registered later. An explicit picker/toggle change
+establishes the current document theme owner.
+
 | Preset   | Use when                                                                    |
 | -------- | --------------------------------------------------------------------------- |
 | `tabby`  | You want a warm neutral SaaS/admin baseline close to the default density.   |

--- a/src/components/_internal/block-layout.ts
+++ b/src/components/_internal/block-layout.ts
@@ -310,6 +310,7 @@ export function applyBlockLayoutStyles(
   );
 
   if (props.rowFrom !== undefined) {
+    styles["--ak-flex-direction-base"] = "column";
     styles[`--ak-flex-direction-${props.rowFrom}`] = "row";
   }
   if (props.center !== undefined) {

--- a/src/components/command-palette/command-palette.tsx
+++ b/src/components/command-palette/command-palette.tsx
@@ -210,7 +210,7 @@ function composeBeforeNavigate(
   onPress: CommandPaletteLinkProps["onPress"],
 ): (event: Event) => void {
   return (event) => {
-    beforeNavigate?.();
+    beforeNavigate?.(event);
     if (!event.defaultPrevented) {
       onPress?.(event);
     }

--- a/src/components/command-palette/command-palette.types.ts
+++ b/src/components/command-palette/command-palette.types.ts
@@ -36,7 +36,7 @@ export type CommandPaletteContentProps = Omit<
 /** Props for the {@link CommandPaletteLink} component. */
 export type CommandPaletteLinkProps = LinkProps & {
   closeOnSelect?: boolean;
-  onBeforeNavigate?: () => void;
+  onBeforeNavigate?: (event: Event) => void;
 };
 
 /** Props for the {@link CommandPaletteList} component. */

--- a/src/components/copy-button/copy-button.tsx
+++ b/src/components/copy-button/copy-button.tsx
@@ -20,12 +20,29 @@ export function CopyButton(props: CopyButtonProps): JSX.Element {
     ...rest
   } = props;
   const copyState = state<CopyState>("idle");
-  let resetTimer: ReturnType<typeof setTimeout> | undefined;
-  getSignal().addEventListener("abort", () => clearTimeout(resetTimer), { once: true });
+  const lifecycle = state<{
+    resetTimer: ReturnType<typeof setTimeout> | undefined;
+    cleanupSignal: AbortSignal | null;
+  }>({ resetTimer: undefined, cleanupSignal: null })();
+  const signal = getSignal();
+  if (lifecycle.cleanupSignal !== signal) {
+    lifecycle.cleanupSignal = signal;
+    signal.addEventListener(
+      "abort",
+      () => {
+        clearTimeout(lifecycle.resetTimer);
+        lifecycle.resetTimer = undefined;
+      },
+      { once: true },
+    );
+  }
 
   const resetLater = () => {
-    clearTimeout(resetTimer);
-    resetTimer = setTimeout(() => copyState.set("idle"), resetAfter);
+    clearTimeout(lifecycle.resetTimer);
+    lifecycle.resetTimer = setTimeout(() => {
+      lifecycle.resetTimer = undefined;
+      copyState.set("idle");
+    }, resetAfter);
   };
   const copy = async () => {
     try {

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -10,7 +10,7 @@ export function Page(props: PageProps): JSX.Element {
   return (
     <Block as="main" grow {...rest} data-slot="page">
       <Container>
-        <Block paddingY="xl" gap="lg">
+        <Block direction="column" paddingY="xl" gap="lg">
           {children}
         </Block>
       </Container>

--- a/src/components/section/section.tsx
+++ b/src/components/section/section.tsx
@@ -7,7 +7,7 @@ export function Section(props: SectionProps): JSX.Element {
   const { children, ...rest } = props;
 
   return (
-    <Block as="section" gap="lg" paddingY="xl" {...rest} data-slot="section">
+    <Block as="section" direction="column" gap="lg" paddingY="xl" {...rest} data-slot="section">
       {children}
     </Block>
   );

--- a/src/components/theme/theme.tsx
+++ b/src/components/theme/theme.tsx
@@ -84,6 +84,22 @@ type InternalThemeScopeValue = ThemeScopeValue & {
   readonly coordinator: ThemeCoordinator | null;
   readonly depth: number;
 };
+type ThemeScopeLifecycle = {
+  cleanupSignal: AbortSignal | null;
+  coordinatorAttached: boolean;
+  persistenceComplete: boolean;
+  storageKey: string;
+  storageListener: ((event: StorageEvent) => void) | null;
+  storageWindow: Window | null;
+};
+
+function detachThemeScopeStorage(lifecycle: ThemeScopeLifecycle): void {
+  if (lifecycle.storageWindow && lifecycle.storageListener) {
+    lifecycle.storageWindow.removeEventListener("storage", lifecycle.storageListener);
+  }
+  lifecycle.storageListener = null;
+  lifecycle.storageWindow = null;
+}
 
 const ThemeScopeContext = defineScope<InternalThemeScopeValue>({
   theme: () => "system",
@@ -122,7 +138,15 @@ export function ThemeScope(props: ThemeScopeProps): JSX.Element {
   // hydration verifier has accepted the server markup.
   const themeState = state<ThemeName>(defaultTheme);
   const localResolvedSystemTheme = state<"light" | "dark">("light");
-  const persistenceAdoption = state({ complete: false })();
+  const lifecycle = state<ThemeScopeLifecycle>({
+    cleanupSignal: null,
+    coordinatorAttached: false,
+    persistenceComplete: false,
+    storageKey,
+    storageListener: null,
+    storageWindow: null,
+  })();
+  lifecycle.storageKey = storageKey;
   const currentTheme = themeState();
   const parentScope = readScope(ThemeScopeContext);
   const ownedCoordinator = state<ThemeCoordinator>(getDefaultThemeCoordinator())();
@@ -131,6 +155,12 @@ export function ThemeScope(props: ThemeScopeProps): JSX.Element {
   coordinator.register(scopeId, scopeDepth, storageKey, currentTheme, scopeSignal, (nextTheme) => {
     if (themeState() !== nextTheme) themeState.set(nextTheme);
   });
+  if (lifecycle.cleanupSignal !== scopeSignal) {
+    lifecycle.cleanupSignal = scopeSignal;
+    scopeSignal.addEventListener("abort", () => detachThemeScopeStorage(lifecycle), {
+      once: true,
+    });
+  }
 
   const setTheme = (nextTheme: ThemeName) => {
     themeState.set(nextTheme);
@@ -150,53 +180,52 @@ export function ThemeScope(props: ThemeScopeProps): JSX.Element {
     coordinator,
     depth: scopeDepth,
   };
+  const bindScope = (element: HTMLElement | null) => {
+    if (element && parentScope.coordinator === null && !lifecycle.coordinatorAttached) {
+      lifecycle.coordinatorAttached = true;
+      coordinator.attach(
+        element,
+        (nextTheme) => localResolvedSystemTheme.set(nextTheme),
+        scopeSignal,
+      );
+    }
+
+    const storageWindow = element?.ownerDocument.defaultView ?? null;
+    if (storageWindow !== lifecycle.storageWindow) {
+      detachThemeScopeStorage(lifecycle);
+      if (storageWindow) {
+        lifecycle.storageWindow = storageWindow;
+        lifecycle.storageListener = (event) => {
+          let storageMatches = event.storageArea == null;
+          try {
+            storageMatches ||= event.storageArea === storageWindow.localStorage;
+          } catch {
+            // Locked-down/private contexts may deny access to localStorage.
+          }
+          if (!storageMatches || event.key !== lifecycle.storageKey) {
+            return;
+          }
+          const nextTheme = event.newValue as ThemeName | null;
+          if (!nextTheme) return;
+          themeState.set(nextTheme);
+          coordinator.activate(scopeId, nextTheme);
+        };
+        storageWindow.addEventListener("storage", lifecycle.storageListener);
+      }
+    }
+
+    if (!element || lifecycle.persistenceComplete) return;
+    lifecycle.persistenceComplete = true;
+    const storedTheme = readStoredTheme(storageKey);
+    if (storedTheme && storedTheme !== themeState()) {
+      themeState.set(storedTheme);
+      coordinator.activate(scopeId, storedTheme);
+    }
+  };
 
   return (
     <ThemeScopeContext value={value}>
-      <div
-        data-slot="theme-scope"
-        ref={
-          parentScope.coordinator === null
-            ? (element: HTMLElement | null) => {
-                coordinator.attach(
-                  element,
-                  (nextTheme) => localResolvedSystemTheme.set(nextTheme),
-                  scopeSignal,
-                );
-                if (element && typeof window !== "undefined") {
-                  const onStorage = (event: StorageEvent) => {
-                    let storageMatches = event.storageArea == null;
-                    try {
-                      storageMatches ||= event.storageArea === window.localStorage;
-                    } catch {
-                      // Locked-down/private contexts may deny access to localStorage.
-                    }
-                    if (!storageMatches || event.key !== storageKey) {
-                      return;
-                    }
-                    const nextTheme = event.newValue as ThemeName | null;
-                    if (!nextTheme) return;
-                    themeState.set(nextTheme);
-                    coordinator.activate(scopeId, nextTheme);
-                  };
-                  window.addEventListener("storage", onStorage);
-                  scopeSignal.addEventListener(
-                    "abort",
-                    () => window.removeEventListener("storage", onStorage),
-                    { once: true },
-                  );
-                }
-                if (!element || persistenceAdoption.complete) return;
-                persistenceAdoption.complete = true;
-                const storedTheme = readStoredTheme(storageKey);
-                if (storedTheme && storedTheme !== themeState()) {
-                  themeState.set(storedTheme);
-                  coordinator.activate(scopeId, storedTheme);
-                }
-              }
-            : undefined
-        }
-      >
+      <div data-slot="theme-scope" ref={bindScope}>
         {children}
       </div>
     </ThemeScopeContext>
@@ -254,12 +283,16 @@ function createThemeCoordinator() {
   };
   const syncActive = (): void => {
     if (explicitOwner !== undefined) return;
-    let candidate: { depth: number; sequence: number; theme: ThemeName } | undefined;
+    let candidate:
+      | { depth: number; identity: string; sequence: number; theme: ThemeName }
+      | undefined;
     for (const scope of scopes.values()) {
       if (
         !candidate ||
         scope.depth > candidate.depth ||
-        (scope.depth === candidate.depth && scope.sequence > candidate.sequence)
+        (scope.depth === candidate.depth &&
+          scope.identity === candidate.identity &&
+          scope.sequence > candidate.sequence)
       ) {
         candidate = scope;
       }

--- a/src/themes/default/styles/shell/sidebar.css
+++ b/src/themes/default/styles/shell/sidebar.css
@@ -23,6 +23,7 @@
 }
 
 :where([data-slot="sidebar"][data-side="right"]) {
+  order: 1;
   border-inline-start: 1px solid var(--ak-color-border);
   border-inline-end: 0;
 }
@@ -226,6 +227,10 @@
 
 :where([data-slot="sidebar-trigger"]) {
   flex: none;
+}
+
+[data-slot="sidebar"][data-collapsible="icon"] {
+  --ak-width-base: var(--ak-layout-sidebar-rail-width);
 }
 
 :where([data-slot="sidebar"][data-collapsible="icon"]) :where([data-slot="sidebar-group-label"]),

--- a/templates/theme/styles/shell/sidebar.css
+++ b/templates/theme/styles/shell/sidebar.css
@@ -23,6 +23,7 @@
 }
 
 :where([data-slot="sidebar"][data-side="right"]) {
+  order: 1;
   border-inline-start: 1px solid var(--ak-color-border);
   border-inline-end: 0;
 }
@@ -226,6 +227,10 @@
 
 :where([data-slot="sidebar-trigger"]) {
   flex: none;
+}
+
+[data-slot="sidebar"][data-collapsible="icon"] {
+  --ak-width-base: var(--ak-layout-sidebar-rail-width);
 }
 
 :where([data-slot="sidebar"][data-collapsible="icon"]) :where([data-slot="sidebar-group-label"]),

--- a/tests/browser/command-palette.test.tsx
+++ b/tests/browser/command-palette.test.tsx
@@ -1,7 +1,7 @@
 import { page, userEvent } from "@vitest/browser/context";
 import { state } from "@askrjs/askr";
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
-import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   CommandHeader,
@@ -43,7 +43,7 @@ function PaletteContent(props: {
   closeOnBackdrop?: boolean;
   closeOnEscape?: boolean;
   linkHref?: string;
-  onBeforeNavigate?: () => void;
+  onBeforeNavigate?: (event: Event) => void;
 }) {
   return (
     <CommandPaletteContent
@@ -277,5 +277,26 @@ describe("CommandPalette", () => {
     expect(targetObservedClosed).toBe(true);
     expect(window.location.pathname).toBe("/guide");
     expect(container!.textContent).toContain("Guide");
+  });
+
+  it("should let onBeforeNavigate cancel navigation and palette dismissal", async () => {
+    const onBeforeNavigate = vi.fn((event: Event) => event.preventDefault());
+    testRoute("/docs", () => (
+      <CommandPalette defaultOpen>
+        <PaletteContent onBeforeNavigate={onBeforeNavigate} linkHref="/guide" />
+      </CommandPalette>
+    ));
+    testRoute("/guide", () => <main>Guide</main>);
+
+    await createSPA({ root: container!, registry: createTestRegistry() });
+    const link = await waitForElement(
+      () => document.body.querySelector('[data-slot="command-item"]') as HTMLAnchorElement | null,
+    );
+    link.click();
+    await settle();
+
+    expect(onBeforeNavigate).toHaveBeenCalledOnce();
+    expect(window.location.pathname).toBe("/docs");
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
   });
 });

--- a/tests/browser/copy-button.test.tsx
+++ b/tests/browser/copy-button.test.tsx
@@ -20,8 +20,15 @@ describe("CopyButton", () => {
     cleanupApp(container);
     container.remove();
     resetTestRoutes();
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
+
+  async function flushCopyUpdates(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
 
   it("should announce success and restore its idle state after copying", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -53,5 +60,32 @@ describe("CopyButton", () => {
       .poll(() => container.querySelector('[data-slot="copy-button-status"]')?.textContent)
       .toBe("Could not copy to clipboard.");
     expect(container.querySelector("button")?.getAttribute("data-state")).toBe("error");
+  });
+
+  it("should refresh one lifetime-owned reset timer after a rapid second copy", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { ...navigator, clipboard: { writeText } });
+    testRoute("/copy", () => (
+      <CopyButton text="resource-123" label="Copy resource ID" resetAfter={1000} />
+    ));
+    await createSPA({ root: container, registry: createTestRegistry() });
+    vi.useFakeTimers();
+
+    container.querySelector("button")?.click();
+    await flushCopyUpdates();
+    expect(container.querySelector("button")?.getAttribute("data-state")).toBe("success");
+
+    await vi.advanceTimersByTimeAsync(300);
+    container.querySelector("button")?.click();
+    await flushCopyUpdates();
+    await vi.advanceTimersByTimeAsync(700);
+    await flushCopyUpdates();
+
+    expect(writeText).toHaveBeenCalledTimes(2);
+    expect(container.querySelector("button")?.getAttribute("data-state")).toBe("success");
+
+    await vi.advanceTimersByTimeAsync(300);
+    await flushCopyUpdates();
+    expect(container.querySelector("button")?.getAttribute("data-state")).toBe("idle");
   });
 });

--- a/tests/browser/public-family-smoke.test.tsx
+++ b/tests/browser/public-family-smoke.test.tsx
@@ -224,7 +224,7 @@ describe("public family browser smoke", () => {
     ).toBe("column");
     expect(
       getComputedStyle(container!.querySelector('[data-slot="page-header"]')!).flexDirection,
-    ).toBe("row");
+    ).toBe(window.matchMedia("(min-width: 48rem)").matches ? "row" : "column");
     const inlineMeta = container!.querySelector('[data-testid="inline-meta"]') as HTMLElement;
     const stackedMeta = container!.querySelector('[data-testid="stacked-meta"]') as HTMLElement;
     expect(inlineMeta.tagName).toBe("DL");

--- a/tests/browser/responsive-visual-contracts.test.tsx
+++ b/tests/browser/responsive-visual-contracts.test.tsx
@@ -88,6 +88,7 @@ describe("responsive and visual theme contracts", () => {
     const mobileSectionPadding = Number.parseFloat(getComputedStyle(section).paddingBlockStart);
 
     expect(getComputedStyle(block).flexDirection).toBe("column");
+    expect(getComputedStyle(section).flexDirection).toBe("column");
     expect(getComputedStyle(toolbar).flexDirection).toBe("column");
     expect(getComputedStyle(pageHeader).flexDirection).toBe("column");
     expect(columnCount(getComputedStyle(grid).gridTemplateColumns)).toBe(1);

--- a/tests/browser/responsive-visual-contracts.test.tsx
+++ b/tests/browser/responsive-visual-contracts.test.tsx
@@ -91,7 +91,18 @@ describe("responsive and visual theme contracts", () => {
     expect(getComputedStyle(toolbar).flexDirection).toBe("column");
     expect(getComputedStyle(pageHeader).flexDirection).toBe("column");
     expect(columnCount(getComputedStyle(grid).gridTemplateColumns)).toBe(1);
-    expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
+    const contentRight = content.getBoundingClientRect().right;
+    const overflowDetails = [content, ...content.querySelectorAll<HTMLElement>("*")]
+      .map((element) => ({
+        slot: element.getAttribute("data-slot") ?? element.tagName.toLowerCase(),
+        clientWidth: element.clientWidth,
+        scrollWidth: element.scrollWidth,
+        right: Math.round(element.getBoundingClientRect().right),
+      }))
+      .filter((entry) => entry.scrollWidth > entry.clientWidth || entry.right > contentRight);
+    expect(content.scrollWidth, JSON.stringify(overflowDetails)).toBeLessThanOrEqual(
+      content.clientWidth,
+    );
 
     await page.viewport(1024, 900);
     await settle();

--- a/tests/browser/responsive-visual-contracts.test.tsx
+++ b/tests/browser/responsive-visual-contracts.test.tsx
@@ -2,7 +2,7 @@ import { page } from "@vitest/browser/context";
 import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
 
-import { Block, Container, Grid, Section, Sidebar } from "../../src/core";
+import { Block, Container, Grid, PageHeader, Section, Sidebar, Toolbar } from "../../src/core";
 import { Input } from "../../src/controls";
 import {
   Dialog,
@@ -69,6 +69,8 @@ describe("responsive and visual theme contracts", () => {
               <div>three</div>
             </Grid>
           </Block>
+          <Toolbar title="A long project title" actions={<button>Toolbar action</button>} />
+          <PageHeader title="Overview" actions={<button>Header action</button>} />
         </Section>
       </Container>
     ));
@@ -80,10 +82,14 @@ describe("responsive and visual theme contracts", () => {
     const grid = container.querySelector<HTMLElement>(".responsive-grid")!;
     const content = container.querySelector<HTMLElement>(".responsive-container")!;
     const section = container.querySelector<HTMLElement>(".responsive-section")!;
+    const toolbar = container.querySelector<HTMLElement>('[data-slot="toolbar"]')!;
+    const pageHeader = container.querySelector<HTMLElement>('[data-slot="page-header"]')!;
     const mobilePadding = Number.parseFloat(getComputedStyle(content).paddingInlineStart);
     const mobileSectionPadding = Number.parseFloat(getComputedStyle(section).paddingBlockStart);
 
     expect(getComputedStyle(block).flexDirection).toBe("column");
+    expect(getComputedStyle(toolbar).flexDirection).toBe("column");
+    expect(getComputedStyle(pageHeader).flexDirection).toBe("column");
     expect(columnCount(getComputedStyle(grid).gridTemplateColumns)).toBe(1);
     expect(content.scrollWidth).toBeLessThanOrEqual(content.clientWidth);
 
@@ -91,6 +97,8 @@ describe("responsive and visual theme contracts", () => {
     await settle();
 
     expect(getComputedStyle(block).flexDirection).toBe("row");
+    expect(getComputedStyle(toolbar).flexDirection).toBe("row");
+    expect(getComputedStyle(pageHeader).flexDirection).toBe("row");
     expect(columnCount(getComputedStyle(grid).gridTemplateColumns)).toBe(3);
     expect(Number.parseFloat(getComputedStyle(content).paddingInlineStart)).toBeGreaterThan(
       mobilePadding,

--- a/tests/browser/sidebar.test.tsx
+++ b/tests/browser/sidebar.test.tsx
@@ -3,6 +3,13 @@ import { afterEach, beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { cleanupApp, createSPA } from "@askrjs/askr/boot";
 
+import {
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarScope,
+} from "../../src/components";
 import { Block, Container, Main, NavGroup, NavLink, PageHeader, Sidebar } from "../../src/core";
 
 import "../../src/themes/default/index.css";
@@ -36,6 +43,48 @@ describe("sidebar browser smoke", () => {
     }
 
     resetTestRoutes();
+  });
+
+  it("should narrow an icon sidebar and dock its right side after the inset", async () => {
+    testRoute("/docs", () => (
+      <SidebarScope>
+        <Sidebar collapsible="icon" side="right" aria-label="Workspace navigation">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton>
+                <svg aria-hidden="true" viewBox="0 0 16 16" />
+                <span>Dashboard</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </Sidebar>
+        <SidebarInset>Workspace</SidebarInset>
+      </SidebarScope>
+    ));
+
+    await createSPA({ root: container!, registry: createTestRegistry() });
+    await settle();
+
+    const scope = container?.querySelector('[data-slot="sidebar-scope"]') as HTMLElement;
+    const sidebar = container?.querySelector('[data-slot="sidebar"]') as HTMLElement;
+    const inset = container?.querySelector('[data-slot="sidebar-inset"]') as HTMLElement;
+    const rootFontSize = px(getComputedStyle(document.documentElement).fontSize);
+    const railWidth =
+      Number.parseFloat(
+        getComputedStyle(sidebar).getPropertyValue("--ak-layout-sidebar-rail-width"),
+      ) * rootFontSize;
+
+    expect(sidebar.getBoundingClientRect().width).toBeCloseTo(railWidth, 0);
+    expect(sidebar.getBoundingClientRect().left).toBeGreaterThanOrEqual(
+      inset.getBoundingClientRect().right - 1,
+    );
+    expect(sidebar.getBoundingClientRect().right).toBeCloseTo(
+      scope.getBoundingClientRect().right,
+      0,
+    );
+    expect(
+      getComputedStyle(container!.querySelector('[data-slot="sidebar-menu-button"] span')!).display,
+    ).toBe("none");
   });
 
   it("should render sidebar as a semantic Block preset beside main content", async () => {

--- a/tests/jsdom/theme-contract.test.tsx
+++ b/tests/jsdom/theme-contract.test.tsx
@@ -345,7 +345,7 @@ describe("theme contracts", () => {
       </ThemeScope>
     );
     const SecondApp = () => (
-      <ThemeScope defaultTheme="light" storageKey="askr-theme-cross-root-b">
+      <ThemeScope defaultTheme="dark" storageKey="askr-theme-cross-root-b">
         <ThemeToggle aria-label="Toggle second theme" />
         <ThemeProbe />
       </ThemeScope>
@@ -364,11 +364,15 @@ describe("theme contracts", () => {
       await createSPA({ root: second, registry: secondRegistry });
       await settle();
 
+      expect(probeTheme(first)).toBe("light");
+      expect(probeTheme(second)).toBe("dark");
+      expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+
       (first.querySelector('[data-theme-control="toggle"]') as HTMLButtonElement).click();
       await settle();
 
       expect(probeTheme(first)).toBe("dark");
-      expect(probeTheme(second)).toBe("light");
+      expect(probeTheme(second)).toBe("dark");
       expect(window.localStorage.getItem("askr-theme-cross-root-a")).toBe("dark");
       expect(window.localStorage.getItem("askr-theme-cross-root-b")).toBeNull();
       expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
@@ -379,9 +383,9 @@ describe("theme contracts", () => {
       await settle();
 
       expect(probeTheme(first)).toBe("light");
-      expect(probeTheme(second)).toBe("dark");
+      expect(probeTheme(second)).toBe("light");
       expect(window.localStorage.getItem("askr-theme-cross-root-a")).toBe("light");
-      expect(window.localStorage.getItem("askr-theme-cross-root-b")).toBe("dark");
+      expect(window.localStorage.getItem("askr-theme-cross-root-b")).toBe("light");
       expect(document.documentElement.getAttribute("data-theme")).toBe("light");
     } finally {
       cleanupApp(first);
@@ -453,6 +457,39 @@ describe("theme contracts", () => {
       "dark",
     );
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("should adopt and receive storage updates for a nested scope identity", async () => {
+    window.localStorage.setItem("askr-theme-nested", "calico");
+    const App = () => (
+      <ThemeScope defaultTheme="light" storageKey="askr-theme">
+        <ThemeProbe id="outer" />
+        <ThemeScope defaultTheme="tabby" storageKey="askr-theme-nested">
+          <ThemeProbe id="inner" />
+        </ThemeScope>
+      </ThemeScope>
+    );
+    testRoute("/theme", App);
+    await createSPA({ root: container!, registry: createTestRegistry() });
+    await settle();
+
+    const probeTheme = (id: string) =>
+      container?.querySelector(`[data-probe-id="${id}"]`)?.getAttribute("data-theme");
+    expect(probeTheme("outer")).toBe("light");
+    expect(probeTheme("inner")).toBe("calico");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("calico");
+
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "askr-theme-nested",
+        newValue: "torty",
+      }),
+    );
+    await settle();
+
+    expect(probeTheme("outer")).toBe("light");
+    expect(probeTheme("inner")).toBe("torty");
+    expect(document.documentElement.getAttribute("data-theme")).toBe("torty");
   });
 
   it("should expose the default theme options and scoped state", async () => {

--- a/tests/unit/block-first-components.test.ts
+++ b/tests/unit/block-first-components.test.ts
@@ -138,6 +138,7 @@ describe("block-first components", () => {
     const header = asElement(Header({ sticky: true, children: "header" }));
     const main = asElement(Main({ children: "main" }));
     const section = asElement(Section({ children: "section" }));
+    const horizontalSection = asElement(Section({ direction: "row", children: "section" }));
     const aside = asElement(Aside({ children: "aside" }));
     const sidebar = asElement(Sidebar({ children: "sidebar" }));
     const navbar = asElement(Navbar({ children: "navbar" }));
@@ -179,6 +180,8 @@ describe("block-first components", () => {
     expect(main.props.as).toBe("main");
     expect(main.props.grow).toBe(true);
     expect(section.props.as).toBe("section");
+    expect(section.props.direction).toBe("column");
+    expect(horizontalSection.props.direction).toBe("row");
     expect(aside.props.as).toBe("aside");
     expect(sidebar.props.as).toBe("aside");
     expect(sidebar.props.width).toBe("sidebar");
@@ -193,7 +196,12 @@ describe("block-first components", () => {
   });
 
   it("should expose common composition components without recipe-only layouts", () => {
-    expect(Page({ children: "page" })).toBeTruthy();
+    const page = asElement(Page({ children: "page" }));
+    const pageContainer = asElement(page.props.children);
+    const pageContent = asElement(pageContainer.props.children);
+
+    expect(pageContent.type).toBe(Block);
+    expect(pageContent.props.direction).toBe("column");
     expect(
       PageHeader({ title: "Projects", description: "Manage work.", actions: "actions" }),
     ).toBeTruthy();

--- a/tests/unit/layout-helpers.test.ts
+++ b/tests/unit/layout-helpers.test.ts
@@ -62,6 +62,7 @@ describe("block layout helpers", () => {
     expect(styles["--ak-flex-wrap-base"]).toBe("wrap");
     expect(styles["--ak-flex-wrap-lg"]).toBe("nowrap");
     expect(styles["--ak-flex-grow-base"]).toBe(1);
+    expect(styles["--ak-flex-direction-base"]).toBe("column");
     expect(styles["--ak-flex-direction-lg"]).toBe("row");
     expect(styles["--ak-display-base"]).toBe("none");
     expect(styles["--ak-display-lg"]).toBe("flex");

--- a/vitest.test.browser.config.ts
+++ b/vitest.test.browser.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     api: {
       host: "127.0.0.1",
     },
+    // Browser files share page-level state such as the viewport. Keep files
+    // serial within each browser instance so responsive tests cannot race.
+    fileParallelism: false,
     globals: true,
     browser: {
       api: {


### PR DESCRIPTION
## Summary

- make `rowFrom` establish the documented column-to-row responsive contract and verify Toolbar/PageHeader at rendered breakpoints
- make Page and Section honor their documented vertical-content defaults without blocking explicit Section overrides
- make right/icon sidebars physically dock and narrow, keeping default theme CSS and the generated theme template identical
- make CommandPaletteLink cancellation real and give CopyButton one lifetime-owned latest-interaction timer
- give every ThemeScope its own persisted storage lifecycle while keeping initial sibling arbitration isolated by storage identity
- serialize browser files within each browser instance so shared viewport mutations cannot race
- document the repaired contracts and extend the regression matrix

## Pattern audits

- audited responsive `*From` layout shorthands and rendered consumers; `rowFrom` is the only shared direction shorthand and Toolbar/PageHeader now have browser geometry coverage
- audited structural vertical-content presets; Page's internal wrapper and Section were the two documented vertical stacks inheriting Block's row default
- audited cancelable callback claims across themes and askr-ui; CommandPaletteLink was the only documented callback whose event was not delivered
- audited local timer ownership; CopyButton was the remaining themes component with a render-local timer
- audited ThemeScope registration, storage, activation, cleanup, nested depth, sibling identity, and explicit-owner paths
- audited browser files that mutate page-level state; viewport-owning files now run serially while Chromium, Firefox, and WebKit remain separate instances
- verified sidebar source/template stylesheet parity after the geometry fixes

## Validation

- `npm run check`
  - lint and TypeScript
  - 623 unit tests
  - 2 checks
  - 60 jsdom tests
  - 231 browser tests across Chromium, Firefox, and WebKit
  - 3 forced-colors tests
  - build, installed-types, publint, package artifacts, and bundle checks
- complete 231-test browser suite in the Ubuntu Playwright container used by CI
- `git diff --check`
- exact source/template sidebar stylesheet parity
- package version remains `0.2.3`; no package or dependency changes

Closes #116
Closes #117
Closes #118
Closes #119
Closes #120
Closes #121
Closes #122
Closes #123
Closes #125
Closes #126
